### PR TITLE
STAAR: fix CCT extreme-tail underflow and sparse path sigma2 scaling

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -34,18 +34,18 @@ If R says `Burden(1,25) = 0.4155`, our Rust must produce the same value.
 
 ## R validation results
 
-| Test | R Package | Tolerance | Status |
-|------|-----------|-----------|--------|
-| CCT (Cauchy combination) | STAAR 0.9.8 | 1e-4 | pass |
-| Beta density weights | STAAR 0.9.8 | 1e-8 | pass |
-| PHRED-to-rank conversion | STAAR 0.9.8 | 1e-8 | pass |
-| Null model (continuous) | STAAR 0.9.8 | 1e-8 | pass |
-| Null model (binary/IRLS) | STAAR 0.9.8 | 1e-3 | pass |
-| Burden(1,25), Burden(1,1) | STAAR 0.9.8 | 1e-4 | pass |
-| SKAT(1,25), SKAT(1,1) | STAAR 0.9.8 | 2e-3 | pass |
-| MultiSTAAR per-trait | MultiSTAAR 0.9.7.1 | -- | pass |
-| SCANG parameters | SCANG 1.0.4 | -- | pass |
-| MetaSTAAR U/K scaling | STAAR 0.9.8 | 1e-8 | pass |
+| Test | R Package | R Source | Tolerance | Status |
+|------|-----------|----------|-----------|--------|
+| CCT (Cauchy combination) | STAAR 0.9.8 | `STAAR/R/CCT.R` | 1e-4 | pass |
+| Beta density weights | STAAR 0.9.8 | `STAAR/R/STAAR.R::Beta_Weight` | 1e-8 | pass |
+| PHRED-to-rank conversion | STAAR 0.9.8 | `STAAR/R/Annotation_Rank.R` | 1e-8 | pass |
+| Null model (continuous) | STAAR 0.9.8 | `STAAR/R/fit_null_glm.R` | 1e-8 | pass |
+| Null model (binary/IRLS) | STAAR 0.9.8 | `STAAR/R/fit_null_glm.R` | 1e-3 | pass |
+| Burden(1,25), Burden(1,1) | STAAR 0.9.8 | `STAAR/R/STAAR.R` | 1e-4 | pass |
+| SKAT(1,25), SKAT(1,1) | STAAR 0.9.8 | `STAAR/R/STAAR.R` | 2e-3 | pass |
+| MultiSTAAR per-trait | MultiSTAAR 0.9.7.1 | `MultiSTAAR/R/MultiSTAAR.R` | -- | pass |
+| SCANG parameters | SCANG 1.0.4 | `SCANG/R/SCANG.R` | -- | pass |
+| MetaSTAAR U/K scaling | MetaSTAAR 0.9.6.3 | `MetaSTAAR/R/MetaSTAAR_worker_sumstat.R` | 1e-8 | pass |
 
 ## Internal invariant tests
 
@@ -60,6 +60,10 @@ The carrier-indexed sparse scoring path (O(total_MAC)) must produce identical U 
 | U: sparse == dense (binary) | 1e-10 | `sparse_dense_parity_binary` |
 | K: sparse == dense (continuous) | 1e-10 | `sparse_dense_parity_continuous` |
 | K: sparse == dense (binary) | 1e-10 | `sparse_dense_parity_binary` |
+| Burden/SKAT/ACAT-V/STAAR-O: raw G == U/K oracle | 1e-9, SKAT 1e-6 | `raw_path_matches_oracle` |
+| Burden/SKAT/ACAT-V/STAAR-O: sparse == U/K oracle | 1e-9, SKAT 1e-6 | `sparse_path_matches_oracle` |
+
+The U/K oracle entry point is `score::run_staar_from_sumstats`, which is directly compared to R STAAR's `STAAR()` by `staar_continuous_matches_r`. The two parity tests above extend that anchor to the raw and sparse scoring paths, covering every Burden/SKAT/ACAT-V variant including the STAAR-O omnibus.
 
 ### Algebraic properties
 These catch index alignment bugs, hidden reorderings, and accumulation errors.
@@ -125,13 +129,13 @@ These are intentional implementation choices, not bugs:
 
 ## Not yet validated against R
 
-| Component | Status | Blocker |
-|-----------|--------|---------|
-| MetaSTAAR cross-study merge | Implemented, R validation pending | Requires multi-study test setup |
-| SCANG threshold search | Window construction tested | Monte Carlo simulation needed |
-| AI-STAAR | Implemented, unit tested | R comparison requires ancestry-stratified test data |
-| MultiSTAAR joint test | Implemented, unit tested | R comparison requires multi-trait test data |
-| SPA (binary traits) | CGF formula validated | Needs balanced binary test case where R returns non-NULL |
+| Component | What is tested | What is not | Blocker |
+|-----------|---------------|-------------|---------|
+| MetaSTAAR cross-study merge | U/K scaling vs R (`meta_staar_validation`) | Cross-study covariance merge in `meta.rs` | Multi-study test setup |
+| SCANG threshold search | Window construction (`masks::tests::scang_*`); R parameter loading | Threshold search vs R | Monte Carlo simulation needed |
+| AI-STAAR | Two-population unit test (`ancestry::tests::ai_staar_two_populations`) | End-to-end vs R | Ancestry-stratified reference data |
+| MultiSTAAR joint test | Per-trait STAAR-O matches R; Rust unit tests for combine | Joint omnibus vs R (`multi_staar_o` is NULL in current reference) | Multi-trait reference where R returns non-NULL |
+| SPA (binary traits) | CGF/derivative correctness (`stats::tests::cgf_*`, `k1_at_zero_is_zero`, `k2_at_zero_equals_variance`); pipeline plumbed via `burden_spa`, `acat_v_spa` | Per-variant SPA p-value vs R STAAR_Binary_SPA | Balanced binary reference where R returns non-NULL |
 
 ## Reproducing validation
 

--- a/src/staar/carrier/sparse_score.rs
+++ b/src/staar/carrier/sparse_score.rs
@@ -120,10 +120,10 @@ impl AnalysisVectors {
 
 /// Score one gene using sparse carrier-indexed computation.
 ///
-/// Returns the U vector (score statistics) and K matrix (kernel/covariance)
-/// as faer::Mat for compatibility with the existing STAAR test engine.
+/// Returns (U/σ², K/σ²) — pre-scaled to the MetaSTAAR sumstats convention so
+/// callers can hand them directly to `score::run_staar_from_sumstats`. For
+/// binary traits σ² is 1 and the scaling is a no-op.
 ///
-/// Accepts carrier lists directly.
 /// For typical rare-variant genes (20 variants × MAC=5 × k=6 covariates),
 /// total work is ~3,300 multiply-adds vs ~27,000,000 for the dense path.
 pub fn score_gene_sparse(
@@ -257,9 +257,10 @@ pub fn score_gene_sparse(
         }
     }
 
-    // Convert to faer::Mat for compatibility with existing test engine
-    let u_mat = Mat::from_fn(m, 1, |i, _| u[i]);
-    let k_mat = Mat::from_fn(m, m, |i, j| kernel_flat[i * m + j]);
+    // Scale to MetaSTAAR sumstats convention: U/σ², K/σ².
+    let inv_s2 = 1.0 / analysis.sigma2;
+    let u_mat = Mat::from_fn(m, 1, |i, _| u[i] * inv_s2);
+    let k_mat = Mat::from_fn(m, m, |i, j| kernel_flat[i * m + j] * inv_s2);
 
     (u_mat, k_mat)
 }
@@ -372,8 +373,8 @@ fn null_model_ref(analysis: &AnalysisVectors) -> NullModel {
     }
 }
 
-/// Compute only U = G'r from carrier lists (Phase 1 of score_gene_sparse).
-/// O(total_MAC) — no K computation. Used for genes exceeding MAX_K_VARIANTS.
+/// Compute U/σ² from carrier lists (Phase 1 of score_gene_sparse).
+/// O(total_MAC), no K. Used for genes exceeding MAX_K_VARIANTS.
 pub fn compute_u_only(
     carriers: &[CarrierList],
     analysis: &AnalysisVectors,
@@ -389,6 +390,10 @@ pub fn compute_u_only(
                 u[j] += dosage as f64 * analysis.residuals[pi as usize];
             }
         }
+    }
+    let inv_s2 = 1.0 / analysis.sigma2;
+    for v in &mut u {
+        *v *= inv_s2;
     }
     u
 }
@@ -460,11 +465,10 @@ mod tests {
         // Fit null model
         let null = model::fit_glm(&y, &x);
 
-        // Dense path
+        let inv_s2 = 1.0 / null.sigma2;
         let u_dense = g_dense.transpose() * &null.residuals;
         let k_dense = null.compute_kernel(&g_dense);
 
-        // Sparse path
         let analysis = AnalysisVectors::from_null_model(&null, &vec![true; null.n_samples]);
         let carriers: Vec<CarrierList> = carrier_lists
             .into_iter()
@@ -472,25 +476,16 @@ mod tests {
             .collect();
         let (u_sparse, k_sparse) = score_gene_sparse(&carriers, &analysis);
 
-        // Check parity
         for j in 0..m {
-            let diff = (u_dense[(j, 0)] - u_sparse[(j, 0)]).abs();
-            assert!(
-                diff < 1e-10,
-                "U[{j}] mismatch: dense={} sparse={} diff={diff}",
-                u_dense[(j, 0)],
-                u_sparse[(j, 0)]
-            );
+            let expected = u_dense[(j, 0)] * inv_s2;
+            let diff = (expected - u_sparse[(j, 0)]).abs();
+            assert!(diff < 1e-10, "U[{j}]: expected={expected} got={} diff={diff}", u_sparse[(j, 0)]);
         }
         for i in 0..m {
             for j in 0..m {
-                let diff = (k_dense[(i, j)] - k_sparse[(i, j)]).abs();
-                assert!(
-                    diff < 1e-10,
-                    "K[{i},{j}] mismatch: dense={} sparse={} diff={diff}",
-                    k_dense[(i, j)],
-                    k_sparse[(i, j)]
-                );
+                let expected = k_dense[(i, j)] * inv_s2;
+                let diff = (expected - k_sparse[(i, j)]).abs();
+                assert!(diff < 1e-10, "K[{i},{j}]: expected={expected} got={} diff={diff}", k_sparse[(i, j)]);
             }
         }
     }
@@ -566,6 +561,139 @@ mod tests {
         }
     }
 
+    /// Deterministic synthetic dataset shared by the e2e p-value parity tests.
+    /// LCG keeps the build reproducible without pulling in an rng dependency.
+    struct SyntheticContinuous {
+        g: Mat<f64>,
+        carriers: Vec<CarrierList>,
+        y: Mat<f64>,
+        x: Mat<f64>,
+        mafs: Vec<f64>,
+        ann: Vec<Vec<f64>>,
+    }
+
+    fn synthetic_continuous() -> SyntheticContinuous {
+        let n: usize = 200;
+        let m: usize = 6;
+        let k: usize = 3;
+        let mut state = 0xdeadbeefu64;
+        let mut next = || {
+            state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            ((state >> 33) as f64) / ((1u64 << 31) as f64)
+        };
+
+        let mut x = Mat::zeros(n, k);
+        for i in 0..n {
+            x[(i, 0)] = 1.0;
+            x[(i, 1)] = next() * 2.0 - 1.0;
+            x[(i, 2)] = next() * 2.0 - 1.0;
+        }
+
+        let mut g = Mat::zeros(n, m);
+        let mut carriers: Vec<CarrierList> =
+            (0..m).map(|_| CarrierList { entries: Vec::new() }).collect();
+        let mut mac = vec![0u32; m];
+        for j in 0..m {
+            for i in 0..n {
+                if next() < 0.05 {
+                    let dosage: u8 = if next() < 0.9 { 1 } else { 2 };
+                    g[(i, j)] = dosage as f64;
+                    carriers[j].entries.push(CarrierEntry { sample_idx: i as u32, dosage });
+                    mac[j] += dosage as u32;
+                }
+            }
+            // Guarantee >=2 carriers so beta-weight masks aren't degenerate.
+            if carriers[j].entries.len() < 2 {
+                let i = (j * 7) % n;
+                if g[(i, j)] == 0.0 {
+                    g[(i, j)] = 1.0;
+                    carriers[j].entries.push(CarrierEntry { sample_idx: i as u32, dosage: 1 });
+                    mac[j] += 1;
+                }
+            }
+        }
+        let mafs: Vec<f64> = mac.iter().map(|&c| c as f64 / (2.0 * n as f64)).collect();
+
+        let mut y = Mat::zeros(n, 1);
+        for i in 0..n {
+            y[(i, 0)] = 0.7 * x[(i, 1)] - 0.3 * x[(i, 2)] + (next() - 0.5) * 0.4;
+        }
+
+        let ann: Vec<Vec<f64>> = (0..2).map(|_| (0..m).map(|_| next()).collect()).collect();
+        SyntheticContinuous { g, carriers, y, x, mafs, ann }
+    }
+
+    fn assert_staar_eq(actual: &StaarResult, expected: &StaarResult) {
+        const TOL: f64 = 1e-9;
+        const TOL_SKAT: f64 = 1e-6;
+        let pairs = [
+            ("burden_1_25", actual.burden_1_25, expected.burden_1_25, TOL),
+            ("burden_1_1", actual.burden_1_1, expected.burden_1_1, TOL),
+            ("skat_1_25", actual.skat_1_25, expected.skat_1_25, TOL_SKAT),
+            ("skat_1_1", actual.skat_1_1, expected.skat_1_1, TOL_SKAT),
+            ("acat_v_1_25", actual.acat_v_1_25, expected.acat_v_1_25, TOL),
+            ("acat_v_1_1", actual.acat_v_1_1, expected.acat_v_1_1, TOL),
+            ("acat_o", actual.acat_o, expected.acat_o, TOL),
+            ("staar_o", actual.staar_o, expected.staar_o, TOL_SKAT),
+            ("staar_b_1_25", actual.staar_b_1_25, expected.staar_b_1_25, TOL),
+            ("staar_b_1_1", actual.staar_b_1_1, expected.staar_b_1_1, TOL),
+            ("staar_s_1_25", actual.staar_s_1_25, expected.staar_s_1_25, TOL_SKAT),
+            ("staar_s_1_1", actual.staar_s_1_1, expected.staar_s_1_1, TOL_SKAT),
+            ("staar_a_1_25", actual.staar_a_1_25, expected.staar_a_1_25, TOL),
+            ("staar_a_1_1", actual.staar_a_1_1, expected.staar_a_1_1, TOL),
+        ];
+        for (name, a, e, tol) in pairs {
+            assert!((a - e).abs() < tol, "{name}: actual={a:e} expected={e:e}");
+        }
+        assert_eq!(actual.per_annotation.len(), expected.per_annotation.len());
+        for (ci, (a_ann, e_ann)) in actual.per_annotation.iter().zip(&expected.per_annotation).enumerate() {
+            for (ti, (&a, &e)) in a_ann.iter().zip(e_ann).enumerate() {
+                let tol = if ti == 2 || ti == 3 { TOL_SKAT } else { TOL };
+                assert!((a - e).abs() < tol, "per_annotation[{ci}][{ti}]: actual={a:e} expected={e:e}");
+            }
+        }
+    }
+
+    /// Build the U/K oracle by hand: U=G'r and K=G'(I-H)G scaled by 1/σ², then
+    /// fed to run_staar_from_sumstats. This entry point is the path validated
+    /// against R STAAR by `staar_continuous_matches_r`.
+    fn oracle(
+        g: &Mat<f64>, null: &crate::staar::model::NullModel,
+        ann: &[Vec<f64>], mafs: &[f64],
+    ) -> StaarResult {
+        let inv_s2 = 1.0 / null.sigma2;
+        let m = mafs.len();
+        let u = g.transpose() * &null.residuals;
+        let k = null.compute_kernel(g);
+        let u_scaled = Mat::from_fn(m, 1, |i, _| u[(i, 0)] * inv_s2);
+        let k_scaled = Mat::from_fn(m, m, |i, j| k[(i, j)] * inv_s2);
+        score::run_staar_from_sumstats(&u_scaled, &k_scaled, ann, mafs, null.n_samples)
+    }
+
+    /// Raw genotype path (`score::run_staar`) must produce identical p-values
+    /// to the U/K oracle for every Burden/SKAT/ACAT-V/omnibus statistic.
+    #[test]
+    fn raw_path_matches_oracle() {
+        let d = synthetic_continuous();
+        let null = model::fit_glm(&d.y, &d.x);
+        let raw = score::run_staar(&d.g, &d.ann, &d.mafs, &null, false);
+        let expected = oracle(&d.g, &null, &d.ann, &d.mafs);
+        assert_staar_eq(&raw, &expected);
+    }
+
+    /// Sparse carrier-list path (`run_staar_sparse`) must produce identical
+    /// p-values to the U/K oracle. Extends sparse-dense parity from U/K to
+    /// the full set of test statistics, including the STAAR-O omnibus.
+    #[test]
+    fn sparse_path_matches_oracle() {
+        let d = synthetic_continuous();
+        let null = model::fit_glm(&d.y, &d.x);
+        let analysis = AnalysisVectors::from_null_model(&null, &vec![true; null.n_samples]);
+        let sparse = run_staar_sparse(&d.carriers, &analysis, &d.ann, &d.mafs, false);
+        let expected = oracle(&d.g, &null, &d.ann, &d.mafs);
+        assert_staar_eq(&sparse, &expected);
+    }
+
     #[test]
     fn singleton_variant() {
         let n = 50;
@@ -598,9 +726,8 @@ mod tests {
         assert_eq!(u.nrows(), 2);
         assert_eq!(k.nrows(), 2);
         assert_eq!(k.ncols(), 2);
-        // U should equal the residual at that sample
-        let diff = (u[(0, 0)] - analysis.residuals[10]).abs();
-        assert!(diff < 1e-10, "Singleton U should equal residual at carrier");
+        let expected = analysis.residuals[10] / analysis.sigma2;
+        assert!((u[(0, 0)] - expected).abs() < 1e-10);
     }
 
     #[test]
@@ -765,6 +892,7 @@ mod tests {
         }
 
         let null = model::fit_glm(&y, &x);
+        let inv_s2 = 1.0 / null.sigma2;
         let u_dense = g_dense.transpose() * &null.residuals;
         let k_dense = null.compute_kernel(&g_dense);
 
@@ -774,12 +902,12 @@ mod tests {
         let (u_sparse, k_sparse) = score_gene_sparse(&carriers, &analysis);
 
         for j in 0..2 {
-            let diff = (u_dense[(j, 0)] - u_sparse[(j, 0)]).abs();
+            let diff = (u_dense[(j, 0)] * inv_s2 - u_sparse[(j, 0)]).abs();
             assert!(diff < 1e-10, "Dense carrier U[{j}] diff={diff}");
         }
         for i in 0..2 {
             for j in 0..2 {
-                let diff = (k_dense[(i, j)] - k_sparse[(i, j)]).abs();
+                let diff = (k_dense[(i, j)] * inv_s2 - k_sparse[(i, j)]).abs();
                 assert!(diff < 1e-10, "Dense carrier K[{i},{j}] diff={diff}");
             }
         }

--- a/src/staar/meta.rs
+++ b/src/staar/meta.rs
@@ -570,7 +570,6 @@ fn emit_chromosome_sparse(
     out: &dyn Output,
 ) -> Result<(), FavorError> {
     let n = analysis.n_pheno;
-    let inv_s2 = 1.0 / analysis.sigma2;
 
     // Build position-based segments (same binning as v1 for output compat)
     let mut coarse: std::collections::BTreeMap<i32, Vec<usize>> =
@@ -659,8 +658,8 @@ fn emit_chromosome_sparse(
             b_maf.append_value(v.maf);
             b_mac.append_value((2.0 * v.maf * n as f64).round() as i32);
             b_n_obs.append_value(n as i32);
-            b_u_stat.append_value(u[(j, 0)] * inv_s2);
-            b_v_stat.append_value(k[(j, j)] * inv_s2);
+            b_u_stat.append_value(u[(j, 0)]);
+            b_v_stat.append_value(k[(j, j)]);
             b_segment_id.append_value(seg_id);
             b_gene.append_value(&v.gene_name);
             b_region.append_value(v.annotation.region_type.as_str());
@@ -700,7 +699,7 @@ fn emit_chromosome_sparse(
         let cov_builder = s_cov_lower.values();
         for i in 0..m {
             for j in 0..=i {
-                cov_builder.append_value(k[(i, j)] * inv_s2);
+                cov_builder.append_value(k[(i, j)]);
             }
         }
         s_cov_lower.append(true);

--- a/src/staar/stats.rs
+++ b/src/staar/stats.rs
@@ -16,6 +16,15 @@ pub fn cauchy_combine(p_values: &[f64]) -> f64 {
     cauchy_combine_weighted(p_values, &[])
 }
 
+/// Smallest positive f64 (denormal). Floor for combined p-values so the
+/// omnibus never underflows to exactly 0 (which becomes -log10(p) = +inf
+/// in summary reports).
+const P_FLOOR: f64 = f64::MIN_POSITIVE * f64::EPSILON; // 5e-324
+
+/// Threshold above which `atan(T)/π` saturates at 0.5 in f64. Past this we
+/// switch to the upper-tail asymptotic `1/(π·T)` (STAAR/R/CCT.R).
+const T_ASYMP: f64 = 1.0e15;
+
 /// Weighted Cauchy combination.
 ///
 /// T = sum(w_i * tan((0.5 - p_i) * pi)) / sum(w_i)
@@ -33,13 +42,12 @@ pub fn cauchy_combine_weighted(p_values: &[f64], weights: &[f64]) -> f64 {
     let mut count = 0;
 
     for (i, &p) in p_values.iter().enumerate() {
-        if !p.is_finite() || p <= 0.0 || p >= 1.0 {
-            // Clamp valid p-values; skip truly invalid ones
-            if p.is_nan() {
-                continue;
-            }
+        if p.is_nan() {
+            continue;
         }
-        let p_clamped = p.clamp(1e-300, 1.0 - 1e-15);
+        // Clamp into (0, 1). The lower bound is the smallest positive double
+        // so the small-p branch still represents fully underflowed inputs.
+        let p_clamped = p.clamp(P_FLOOR, 1.0 - 1e-15);
         let w = if use_weights { weights[i].max(0.0) } else { 1.0 };
         if w == 0.0 {
             continue;
@@ -60,8 +68,18 @@ pub fn cauchy_combine_weighted(p_values: &[f64], weights: &[f64]) -> f64 {
     }
 
     let t = t_sum / w_sum;
-    let p = 0.5 - t.atan() / PI;
-    p.clamp(0.0, 1.0)
+
+    // |T| > T_ASYMP: atan(T)/π saturates at 0.5 in f64. Switch to the
+    // upper-tail asymptotic 1/(π·T) (STAAR/R/CCT.R).
+    let p = if t > T_ASYMP {
+        1.0 / (PI * t)
+    } else if t < -T_ASYMP {
+        1.0 - 1.0 / (PI * -t)
+    } else {
+        0.5 - t.atan() / PI
+    };
+
+    p.clamp(P_FLOOR, 1.0)
 }
 
 // ---------------------------------------------------------------------------
@@ -373,6 +391,48 @@ mod tests {
         let equal = cauchy_combine(&pvals);
         let weighted = cauchy_combine_weighted(&pvals, &[1.0, 1.0, 1.0]);
         assert!((equal - weighted).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_cauchy_combine_extreme_underflow() {
+        // Many ultra-small p-values: naive formula returns 0.0 because
+        // atan(T)/π saturates at 0.5 in f64. Asymptotic branch must return
+        // a positive denormal that respects the harmonic-mean asymptotic.
+        let pvals = vec![1e-200; 6];
+        let p = cauchy_combine(&pvals);
+        assert!(p > 0.0, "must not underflow to zero: {p:e}");
+        assert!(p.is_finite(), "must be finite: {p:e}");
+        // For equal weights and p_i = p0, asymptotic gives p ≈ p0 (harmonic
+        // mean of K identical values is the value itself).
+        assert!((p - 1e-200).abs() < 1e-205, "expected ~1e-200, got {p:e}");
+    }
+
+    #[test]
+    fn test_cauchy_combine_monotone_in_tail() {
+        // Combining smaller p-values must yield a smaller (or equal) result.
+        let p_a = cauchy_combine(&[1e-100, 1e-100, 1e-100]);
+        let p_b = cauchy_combine(&[1e-200, 1e-200, 1e-200]);
+        assert!(p_b < p_a, "smaller inputs must give smaller p: {p_a:e} vs {p_b:e}");
+    }
+
+    #[test]
+    fn test_cauchy_combine_floors_at_denormal() {
+        // Even at absolute floor (one input is 0.0), result must be positive
+        // and at least the smallest representable positive double.
+        let p = cauchy_combine(&[0.0, 0.5, 0.5]);
+        assert!(p > 0.0, "must floor to >0: {p:e}");
+        assert!(p >= f64::MIN_POSITIVE * f64::EPSILON);
+    }
+
+    #[test]
+    fn test_cauchy_combine_harmonic_asymptotic() {
+        // Mixed extreme p-values: result should approximate harmonic-mean
+        // form K / sum(1/p_i) when all inputs are << 1e-16.
+        let pvals = [1e-50, 2e-80, 3e-100];
+        let p = cauchy_combine(&pvals);
+        let expected = pvals.len() as f64 / pvals.iter().map(|p| 1.0 / p).sum::<f64>();
+        let rel_err = (p - expected).abs() / expected;
+        assert!(rel_err < 1e-3, "p={p:e} expected={expected:e} rel_err={rel_err:e}");
     }
 
     #[test]


### PR DESCRIPTION
Two STAAR fixes plus end-to-end p-value parity tests.

#2 — CCT underflow

When per-test p-values get small enough (Burden/SKAT/ACAT-V on rare-variant scans on chr22 b0 UKB run), the Cauchy combination's `T = sum(tan((0.5 - p)*pi))` blows past 1e16. At that point `atan(T)/pi` saturates at 0.5 in f64, and `0.5 - atan(T)/pi` returns exactly 0. Fix matches `STAAR/R/CCT.R`: for `|T| > 1e15` use the upper-tail asymptotic `1/(pi*T)` instead. Floor combined p at the smallest positive denormal so `-log10(p)` in summary reports never produces `+inf`. Four regression tests.

#3 — End-to-end ground truth

Two new tests run a deterministic synthetic dataset through `score::run_staar` (raw genotype path) and `run_staar_sparse` (carrier-list path), and compare every Burden/SKAT/ACAT-V/STAAR-O statistic against an explicit U/K oracle that goes through `run_staar_from_sumstats`. The oracle is the path `staar_continuous_matches_r` already validates against R STAAR, so this gives R-anchored coverage of the two scoring entry points that previously only had U/K-level parity.

Sparse sigma2 scaling bug

`sparse_path_matches_oracle` failed on the first run and uncovered a real bug. `score_gene_sparse` was returning raw `U = G'r` and `K = G'(I−H)G`, but `run_staar_from_sumstats` hardcodes `sigma2 = 1` and assumes pre-scaled inputs (the MetaSTAAR sumstats convention — `MetaSTAAR/R/MetaSTAAR_worker_sumstat.R` uses `scaled.residuals` and `Sigma_i = I/sigma2`). The single-study scoring path, sliding windows, and SCANG window scoring all passed raw values through, so Burden/SKAT chi-squares were off by a factor of `sigma2` for any continuous trait where `sigma2 ≠ 1`. Hidden in CI because:

- the existing sparse-dense parity test only compared U/K, never the resulting p-values
- the R-anchored test loaded pre-scaled U/K from JSON and never went through `score_gene_sparse`
- most synthetic test phenotypes had `sigma2 ≈ 1`

`meta::emit_chromosome_sparse` was the only consumer that scaled correctly, so it had a duplicate `* inv_s2` which is now removed.

Fixed by scaling at the source: `score_gene_sparse` and `compute_u_only` now return `(U/sigma2, K/sigma2)`. Binary trait `sigma2 = 1` so it's a no-op there. `sparse_dense_parity_continuous`, `dense_carrier_variant`, and `singleton_variant` updated to expect scaled output.

`docs/validation.md` now cites the exact R source file for every validated test, lists the two new parity tests under sparse-dense parity, and rewrites the "Not yet validated against R" section to be precise about what's covered for MetaSTAAR merge, SCANG threshold, AI-STAAR, MultiSTAAR joint, and SPA binary.

`cargo test --bin favor` 135/135, `cargo clippy --bin favor --tests -- -D warnings` clean.

Closes #2
Closes #3