### PR TITLE
STAAR: port AI_STAAR from upstream R

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -133,7 +133,7 @@ These are intentional implementation choices, not bugs:
 |-----------|---------------|-------------|---------|
 | MetaSTAAR cross-study merge | U/K scaling vs R (`meta_staar_validation`) | Cross-study covariance merge in `meta.rs` | Multi-study test setup |
 | SCANG threshold search | Window construction (`masks::tests::scang_*`); R parameter loading | Threshold search vs R | Monte Carlo simulation needed |
-| AI-STAAR | Two-population unit test (`ancestry::tests::ai_staar_two_populations`) | End-to-end vs R | Ancestry-stratified reference data |
+| AI-STAAR | Algorithm mirrors `STAAR/R/AI_STAAR.R` with the weight scheme from `STAARpipeline/R/staar2aistaar_nullmodel.R`. B=0 parity vs two standard STAAR runs Cauchy-combined element-wise; carrier-list vs dense entry point parity; flatten/unflatten round-trip; ensemble-weight determinism. | Numeric match against an R `AI_STAAR` run on the same fixture | R fixture needs pre-populated `pop_weights_1_1`/`pop_weights_1_25` and a shared RNG; R's MT seed isn't bit-exact across languages. |
 | MultiSTAAR joint test | Per-trait STAAR-O matches R; Rust unit tests for combine | Joint omnibus vs R (`multi_staar_o` is NULL in current reference) | Multi-trait reference where R returns non-NULL |
 | SPA (binary traits) | CGF/derivative correctness (`stats::tests::cgf_*`, `k1_at_zero_is_zero`, `k2_at_zero_equals_variance`); pipeline plumbed via `burden_spa`, `acat_v_spa` | Per-variant SPA p-value vs R STAAR_Binary_SPA | Balanced binary reference where R returns non-NULL |
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,6 +33,7 @@ pub struct Cli {
 }
 
 #[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)]
 pub enum Command {
     /// Initialize a project directory with agent context files
     Init {
@@ -171,6 +172,14 @@ pub enum Command {
         /// AI-STAAR: population group column in phenotype file (activates ancestry-informed weights)
         #[arg(long)]
         ancestry_col: Option<String>,
+
+        /// AI-STAAR ensemble base tests B
+        #[arg(long, default_value = "5")]
+        ai_base_tests: usize,
+
+        /// AI-STAAR ensemble weight RNG seed
+        #[arg(long, default_value = "7590")]
+        ai_seed: u64,
 
         /// SCANG minimum variants per window [default: 40]
         #[arg(long, default_value = "40")]

--- a/src/commands/staar.rs
+++ b/src/commands/staar.rs
@@ -29,6 +29,9 @@ pub fn run(
     window_size: u32,
     individual: bool,
     spa: bool,
+    ancestry_col: Option<String>,
+    ai_base_tests: usize,
+    ai_seed: u64,
     scang_lmin: usize,
     scang_lmax: usize,
     scang_step: usize,
@@ -43,6 +46,7 @@ pub fn run(
     let config = validate_and_parse(
         genotypes, phenotype, trait_names, covariates, annotations, masks,
         maf_cutoff, window_size, individual, spa,
+        ancestry_col, ai_base_tests, ai_seed,
         scang_lmin, scang_lmax, scang_step, known_loci, emit_sumstats,
         rebuild_store, column_map, output_path,
     )?;
@@ -67,6 +71,9 @@ fn validate_and_parse(
     window_size: u32,
     individual: bool,
     spa: bool,
+    ancestry_col: Option<String>,
+    ai_base_tests: usize,
+    ai_seed: u64,
     scang_lmin: usize,
     scang_lmax: usize,
     scang_step: usize,
@@ -157,6 +164,11 @@ fn validate_and_parse(
 
     let store_dir = output_dir.join("store");
 
+    let ancestry_col = ancestry_col.and_then(|s| {
+        let trimmed = s.trim().to_string();
+        if trimmed.is_empty() { None } else { Some(trimmed) }
+    });
+
     Ok(StaarConfig {
         genotypes,
         phenotype,
@@ -168,6 +180,9 @@ fn validate_and_parse(
         window_size,
         individual,
         spa,
+        ancestry_col,
+        ai_base_tests,
+        ai_seed,
         scang_params: staar::masks::ScangParams {
             lmin: scang_lmin,
             lmax: scang_lmax,

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,9 @@ fn run(
             window_size,
             individual,
             spa,
-            ancestry_col: _ancestry_col,
+            ancestry_col,
+            ai_base_tests,
+            ai_seed,
             scang_lmin,
             scang_lmax,
             scang_step,
@@ -90,6 +92,7 @@ fn run(
         } => commands::staar::run(
             genotypes, phenotype, trait_name, covariates, annotations,
             masks, maf_cutoff, window_size, individual, spa,
+            ancestry_col, ai_base_tests, ai_seed,
             scang_lmin, scang_lmax, scang_step,
             known_loci, emit_sumstats, rebuild_store,
             column_map, output_path, out, dry_run,

--- a/src/staar/ancestry.rs
+++ b/src/staar/ancestry.rs
@@ -1,35 +1,109 @@
+//! AI-STAAR. Mirrors `STAAR/R/AI_STAAR.R` and the weight generator in
+//! `STAARpipeline/R/staar2aistaar_nullmodel.R`.
+
+#![allow(clippy::needless_range_loop)]
+
 use faer::Mat;
 
+use super::carrier::reader::{CarrierEntry, CarrierList};
+use super::carrier::sparse_score::{self, AnalysisVectors};
 use super::model::NullModel;
 use super::score::{self, StaarResult};
 use super::stats;
 
-/// Ancestry-informed STAAR: uses population-specific allele frequencies
-/// as weights to leverage allelic heterogeneity across ancestries.
-///
-/// For each population group, variants rare in that population get higher
-/// weight, preventing rare-in-one/common-in-another dilution that reduces
-/// power in multi-ancestry cohorts.
-///
-/// Reference: Li et al. (2024), AI-STAAR in xihaoli/STAAR
-#[allow(dead_code)] // fields read by run_ai_staar when --ancestry-col is used
-/// Per-population allele frequencies and group assignments.
 pub struct AncestryInfo {
-    /// Population group label for each sample (0-indexed).
     pub group: Vec<usize>,
-    /// Number of distinct populations.
     pub n_pops: usize,
+    /// n_pops × (B+1). Column 0 is all-ones, columns 1..=B are |N(0,1)|.
+    pub pop_weights_1_1: Vec<Vec<f64>>,
+    pub pop_weights_1_25: Vec<Vec<f64>>,
 }
 
-/// Run AI-STAAR for one gene.
-///
-/// Computes two scenarios:
-///   Scenario 1: ancestry-ensemble weights (population-specific beta weights)
-///   Scenario 2: annotation × ancestry weights
-/// Final p-value: Cauchy combination of all tests across both scenarios.
-///
-/// `pop_mafs[variant][population]` = MAF in that population.
-#[allow(dead_code)] // wired when --ai-staar lands (v0.2.0)
+impl AncestryInfo {
+    pub fn new(group: Vec<usize>, n_pops: usize, n_base_tests: usize, seed: u64) -> Self {
+        let n_cols = n_base_tests + 1;
+        let mut pop_weights_1_1 = vec![vec![1.0; n_cols]; n_pops];
+        let mut pop_weights_1_25 = vec![vec![1.0; n_cols]; n_pops];
+        let mut rng = Lcg::new(seed);
+        for k in 0..n_pops {
+            for b in 1..n_cols {
+                pop_weights_1_1[k][b] = rng.next_normal().abs();
+            }
+        }
+        for k in 0..n_pops {
+            for b in 1..n_cols {
+                pop_weights_1_25[k][b] = rng.next_normal().abs();
+            }
+        }
+        Self {
+            group,
+            n_pops,
+            pop_weights_1_1,
+            pop_weights_1_25,
+        }
+    }
+}
+
+/// `pop_mafs[v][p] = MAC_p / (2 * n_p)`.
+pub fn pop_mafs_from_carriers(
+    carriers: &[CarrierList],
+    analysis: &AnalysisVectors,
+    ancestry: &AncestryInfo,
+) -> Vec<Vec<f64>> {
+    let m = carriers.len();
+    let n_pops = ancestry.n_pops;
+
+    let mut pop_n = vec![0usize; n_pops];
+    for &g in &ancestry.group {
+        pop_n[g] += 1;
+    }
+
+    let mut pop_mac = vec![vec![0u64; n_pops]; m];
+    for (j, clist) in carriers.iter().enumerate() {
+        for &CarrierEntry { sample_idx, dosage } in &clist.entries {
+            if dosage == 255 {
+                continue;
+            }
+            let pi = match analysis.vcf_to_pheno[sample_idx as usize] {
+                Some(idx) => idx as usize,
+                None => continue,
+            };
+            pop_mac[j][ancestry.group[pi]] += dosage as u64;
+        }
+    }
+
+    pop_mac
+        .into_iter()
+        .map(|mac_per_pop| {
+            mac_per_pop
+                .into_iter()
+                .enumerate()
+                .map(|(p, mac)| {
+                    if pop_n[p] == 0 {
+                        0.0
+                    } else {
+                        mac as f64 / (2.0 * pop_n[p] as f64)
+                    }
+                })
+                .collect()
+        })
+        .collect()
+}
+
+pub fn run_ai_staar_gene(
+    carriers: &[CarrierList],
+    analysis: &AnalysisVectors,
+    ancestry: &AncestryInfo,
+    annotation_matrix: &[Vec<f64>],
+    use_spa: bool,
+) -> StaarResult {
+    let g = sparse_score::carriers_to_dense(carriers, analysis);
+    let pop_mafs = pop_mafs_from_carriers(carriers, analysis, ancestry);
+    let null = sparse_score::null_model_from_analysis(analysis);
+    run_ai_staar(&g, annotation_matrix, &pop_mafs, ancestry, &null, use_spa)
+}
+
+/// `pop_mafs[v][p]` = unfolded MAF of variant v in population p.
 pub fn run_ai_staar(
     g: &Mat<f64>,
     annotation_matrix: &[Vec<f64>],
@@ -41,112 +115,495 @@ pub fn run_ai_staar(
     let m = g.ncols();
     let n = g.nrows();
     let n_pops = ancestry.n_pops;
+    let n_channels = annotation_matrix.len();
 
-    if m == 0 || n_pops == 0 {
-        let zero_mafs = vec![0.01; m];
-        return score::run_staar(g, annotation_matrix, &zero_mafs, null, use_spa);
+    if m == 0 || n_pops == 0 || ancestry.pop_weights_1_1.is_empty() {
+        let pooled = pooled_mafs_from_g(g);
+        return score::run_staar(g, annotation_matrix, &pooled, null, use_spa);
     }
 
-    // Population sample counts for weighted pooling
-    let mut pop_n = vec![0usize; n_pops];
-    for &p in &ancestry.group { pop_n[p] += 1; }
+    // a_p[k] = dbeta(mean folded MAF in pop k, 1, 25), else 0.
+    let mut a_p = vec![0.0f64; n_pops];
+    for k in 0..n_pops {
+        let mut sum = 0.0;
+        for v in 0..m {
+            let maf = pop_mafs.get(v).and_then(|r| r.get(k)).copied().unwrap_or(0.0);
+            sum += maf.min(1.0 - maf);
+        }
+        let mean = sum / m as f64;
+        a_p[k] = if mean > 0.0 {
+            score::beta_density_weight(mean, 1.0, 25.0)
+        } else {
+            0.0
+        };
+    }
 
-    // Scenario 1: per-population genotype matrices with population-specific MAFs.
-    // Zero out samples not in population p; run_staar applies beta(maf_p, 1, 25)
-    // weighting internally via the population-specific MAFs.
-    let mut scenario1_results: Vec<StaarResult> = Vec::with_capacity(n_pops);
-    let mut g_pop = Mat::zeros(n, m);
+    let mafs = pooled_mafs_from_g(g);
 
-    for p in 0..n_pops {
-        for j in 0..m {
-            for i in 0..n {
-                g_pop[(i, j)] = if ancestry.group[i] == p { g[(i, j)] } else { 0.0 };
+    let n_cols = ancestry.pop_weights_1_1[0].len();
+    let mut all_runs: Vec<Vec<f64>> = Vec::with_capacity(2 * n_cols);
+    let mut g1 = Mat::zeros(n, m);
+    let mut g2 = Mat::zeros(n, m);
+
+    for b in 0..n_cols {
+        let w_b_1: Vec<f64> = (0..n_pops).map(|k| ancestry.pop_weights_1_1[k][b]).collect();
+        let w_b_2: Vec<f64> = (0..n_pops)
+            .map(|k| a_p[k] * ancestry.pop_weights_1_25[k][b])
+            .collect();
+
+        for i in 0..n {
+            let pop = ancestry.group[i];
+            let s1 = w_b_1[pop];
+            let s2 = w_b_2[pop];
+            for j in 0..m {
+                let v = g[(i, j)];
+                g1[(i, j)] = s1 * v;
+                g2[(i, j)] = s2 * v;
             }
         }
-        let pop_mafs_p: Vec<f64> = pop_mafs.iter()
-            .map(|v| v.get(p).copied().unwrap_or(0.01).clamp(1e-10, 0.499))
-            .collect();
-        scenario1_results.push(score::run_staar(
-            &g_pop, annotation_matrix, &pop_mafs_p, null, use_spa,
-        ));
+
+        let r1 = score::run_staar(&g1, annotation_matrix, &mafs, null, use_spa);
+        let r2 = score::run_staar(&g2, annotation_matrix, &mafs, null, use_spa);
+        all_runs.push(flatten_staar(&r1, n_channels));
+        all_runs.push(flatten_staar(&r2, n_channels));
     }
 
-    // Scenario 2: standard STAAR with sample-size-weighted pooled MAF
-    let total_n: f64 = pop_n.iter().sum::<usize>() as f64;
-    let pooled_mafs: Vec<f64> = pop_mafs
-        .iter()
-        .map(|maf_vec| {
-            let weighted: f64 = maf_vec.iter().enumerate()
-                .map(|(p, &maf)| maf * pop_n[p] as f64)
-                .sum();
-            (weighted / total_n).clamp(1e-10, 0.499)
+    let len = 6 * (1 + n_channels);
+    let mut aggregated = vec![0.0f64; len];
+    let mut row = Vec::with_capacity(all_runs.len());
+    for i in 0..len {
+        row.clear();
+        row.extend(all_runs.iter().map(|v| v[i]));
+        aggregated[i] = stats::cauchy_combine(&row);
+    }
+
+    unflatten_staar(&aggregated, n_channels)
+}
+
+fn pooled_mafs_from_g(g: &Mat<f64>) -> Vec<f64> {
+    let n = g.nrows();
+    let m = g.ncols();
+    (0..m)
+        .map(|j| {
+            let mut mac = 0.0;
+            for i in 0..n {
+                mac += g[(i, j)];
+            }
+            (mac / (2.0 * n as f64)).clamp(1e-10, 0.499)
         })
-        .collect();
-    let scenario2 = score::run_staar(g, annotation_matrix, &pooled_mafs, null, use_spa);
+        .collect()
+}
 
-    // Combine: Cauchy across all scenarios' STAAR-O values
-    let mut all_staar_o: Vec<f64> = scenario1_results.iter().map(|r| r.staar_o).collect();
-    all_staar_o.push(scenario2.staar_o);
+// Block order matches AI_STAAR.R indexing into pvalues_aggregate:
+// SKAT(1,25), SKAT(1,1), Burden(1,25), Burden(1,1), ACAT-V(1,25), ACAT-V(1,1).
+// Each block: MAF-only p-value first, then one entry per annotation channel.
+// Length = 6 * (1 + n_channels).
+fn flatten_staar(result: &StaarResult, n_channels: usize) -> Vec<f64> {
+    let na = 1 + n_channels;
+    let mut v = Vec::with_capacity(6 * na);
+    // per_annotation index: 0=B(1,25) 1=B(1,1) 2=S(1,25) 3=S(1,1) 4=A(1,25) 5=A(1,1)
+    v.push(result.skat_1_25);
+    for ch in 0..n_channels {
+        v.push(result.per_annotation[ch][2]);
+    }
+    v.push(result.skat_1_1);
+    for ch in 0..n_channels {
+        v.push(result.per_annotation[ch][3]);
+    }
+    v.push(result.burden_1_25);
+    for ch in 0..n_channels {
+        v.push(result.per_annotation[ch][0]);
+    }
+    v.push(result.burden_1_1);
+    for ch in 0..n_channels {
+        v.push(result.per_annotation[ch][1]);
+    }
+    v.push(result.acat_v_1_25);
+    for ch in 0..n_channels {
+        v.push(result.per_annotation[ch][4]);
+    }
+    v.push(result.acat_v_1_1);
+    for ch in 0..n_channels {
+        v.push(result.per_annotation[ch][5]);
+    }
+    v
+}
 
-    let mut combined = scenario2;
-    combined.staar_o = stats::cauchy_combine(&all_staar_o);
-    combined.acat_o = stats::cauchy_combine(
-        &scenario1_results
-            .iter()
-            .map(|r| r.acat_o)
-            .chain(std::iter::once(combined.acat_o))
-            .collect::<Vec<_>>(),
-    );
+// Inverse of flatten_staar. STAAR-O = CCT over the full vector;
+// ACAT-O = CCT over the 6 base p-values; per-test omni = CCT over each block.
+fn unflatten_staar(flat: &[f64], n_channels: usize) -> StaarResult {
+    let na = 1 + n_channels;
 
-    combined
+    let skat_1_25 = flat[0];
+    let skat_1_1 = flat[na];
+    let burden_1_25 = flat[2 * na];
+    let burden_1_1 = flat[3 * na];
+    let acat_v_1_25 = flat[4 * na];
+    let acat_v_1_1 = flat[5 * na];
+
+    let mut per_annotation: Vec<[f64; 6]> = Vec::with_capacity(n_channels);
+    for ch in 0..n_channels {
+        per_annotation.push([
+            flat[2 * na + 1 + ch],
+            flat[3 * na + 1 + ch],
+            flat[1 + ch],
+            flat[na + 1 + ch],
+            flat[4 * na + 1 + ch],
+            flat[5 * na + 1 + ch],
+        ]);
+    }
+
+    let staar_s_1_25 = stats::cauchy_combine(&flat[0..na]);
+    let staar_s_1_1 = stats::cauchy_combine(&flat[na..2 * na]);
+    let staar_b_1_25 = stats::cauchy_combine(&flat[2 * na..3 * na]);
+    let staar_b_1_1 = stats::cauchy_combine(&flat[3 * na..4 * na]);
+    let staar_a_1_25 = stats::cauchy_combine(&flat[4 * na..5 * na]);
+    let staar_a_1_1 = stats::cauchy_combine(&flat[5 * na..6 * na]);
+
+    let acat_o = stats::cauchy_combine(&[
+        skat_1_25,
+        skat_1_1,
+        burden_1_25,
+        burden_1_1,
+        acat_v_1_25,
+        acat_v_1_1,
+    ]);
+    let staar_o = stats::cauchy_combine(flat);
+
+    StaarResult {
+        burden_1_25,
+        burden_1_1,
+        skat_1_25,
+        skat_1_1,
+        acat_v_1_25,
+        acat_v_1_1,
+        per_annotation,
+        staar_b_1_25,
+        staar_b_1_1,
+        staar_s_1_25,
+        staar_s_1_1,
+        staar_a_1_25,
+        staar_a_1_1,
+        acat_o,
+        staar_o,
+    }
+}
+
+// LCG + Box-Muller for ensemble-weight generation.
+struct Lcg {
+    state: u64,
+}
+
+impl Lcg {
+    fn new(seed: u64) -> Self {
+        Self {
+            state: seed.wrapping_add(0x9E3779B97F4A7C15),
+        }
+    }
+    fn next_u64(&mut self) -> u64 {
+        self.state = self
+            .state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        self.state
+    }
+    fn next_unit(&mut self) -> f64 {
+        ((self.next_u64() >> 11) as f64) / ((1u64 << 53) as f64)
+    }
+    fn next_normal(&mut self) -> f64 {
+        let u1 = self.next_unit().max(f64::MIN_POSITIVE);
+        let u2 = self.next_unit();
+        (-2.0 * u1.ln()).sqrt() * (2.0 * std::f64::consts::PI * u2).cos()
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::model;
+    use super::*;
 
     #[test]
-    fn ai_staar_two_populations() {
-        let n = 40;
+    fn pop_mafs_match_per_pop_mac() {
+        let analysis = AnalysisVectors {
+            residuals: vec![0.0; 6],
+            x_row_major: vec![1.0; 6],
+            xtx_inv: vec![1.0],
+            sigma2: 1.0,
+            k: 1,
+            n_pheno: 6,
+            n_vcf_total: 6,
+            working_weights: Vec::new(),
+            fitted_values: Vec::new(),
+            vcf_to_pheno: (0..6).map(|i| Some(i as u32)).collect(),
+        };
+        let ancestry = AncestryInfo::new(vec![0, 0, 0, 1, 1, 1], 2, 0, 7590);
+        let carriers = vec![
+            CarrierList {
+                entries: vec![
+                    CarrierEntry { sample_idx: 0, dosage: 1 },
+                    CarrierEntry { sample_idx: 2, dosage: 2 },
+                ],
+            },
+            CarrierList {
+                entries: vec![
+                    CarrierEntry { sample_idx: 1, dosage: 1 },
+                    CarrierEntry { sample_idx: 4, dosage: 1 },
+                ],
+            },
+        ];
+
+        let pop_mafs = pop_mafs_from_carriers(&carriers, &analysis, &ancestry);
+
+        // variant 0: pop0 MAC=3 (1+2), pop1 MAC=0 → 3/6, 0/6
+        assert!((pop_mafs[0][0] - 0.5).abs() < 1e-12);
+        assert!(pop_mafs[0][1].abs() < 1e-12);
+        // variant 1: pop0 MAC=1, pop1 MAC=1 → 1/6, 1/6
+        assert!((pop_mafs[1][0] - 1.0 / 6.0).abs() < 1e-12);
+        assert!((pop_mafs[1][1] - 1.0 / 6.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn pop_mafs_skip_samples_without_phenotype() {
+        let analysis = AnalysisVectors {
+            residuals: vec![0.0; 3],
+            x_row_major: vec![1.0; 3],
+            xtx_inv: vec![1.0],
+            sigma2: 1.0,
+            k: 1,
+            n_pheno: 3,
+            n_vcf_total: 4,
+            working_weights: Vec::new(),
+            fitted_values: Vec::new(),
+            vcf_to_pheno: vec![Some(0), None, Some(1), Some(2)],
+        };
+        let ancestry = AncestryInfo::new(vec![0, 0, 1], 2, 0, 7590);
+        let carriers = vec![CarrierList {
+            entries: vec![
+                CarrierEntry { sample_idx: 0, dosage: 1 },
+                CarrierEntry { sample_idx: 1, dosage: 2 }, // dropped: no phenotype
+                CarrierEntry { sample_idx: 3, dosage: 1 },
+            ],
+        }];
+        let pop_mafs = pop_mafs_from_carriers(&carriers, &analysis, &ancestry);
+        // pop0: 2 samples, MAC=1 → 1/4. pop1: 1 sample, MAC=1 → 1/2.
+        assert!((pop_mafs[0][0] - 0.25).abs() < 1e-12);
+        assert!((pop_mafs[0][1] - 0.5).abs() < 1e-12);
+    }
+
+    #[test]
+    fn ensemble_weights_first_column_is_ones() {
+        let info = AncestryInfo::new(vec![0, 0, 1, 1], 2, 5, 7590);
+        assert_eq!(info.pop_weights_1_1.len(), 2);
+        assert_eq!(info.pop_weights_1_25.len(), 2);
+        assert_eq!(info.pop_weights_1_1[0].len(), 6);
+        for k in 0..2 {
+            assert_eq!(info.pop_weights_1_1[k][0], 1.0);
+            assert_eq!(info.pop_weights_1_25[k][0], 1.0);
+        }
+        for k in 0..2 {
+            for b in 1..6 {
+                assert!(info.pop_weights_1_1[k][b] >= 0.0);
+                assert!(info.pop_weights_1_25[k][b] >= 0.0);
+            }
+        }
+    }
+
+    #[test]
+    fn ensemble_weights_are_deterministic() {
+        let a = AncestryInfo::new(vec![0, 1], 2, 4, 7590);
+        let b = AncestryInfo::new(vec![0, 1], 2, 4, 7590);
+        assert_eq!(a.pop_weights_1_1, b.pop_weights_1_1);
+        assert_eq!(a.pop_weights_1_25, b.pop_weights_1_25);
+    }
+
+    // B=0 → two STAAR runs (G, G row-scaled by a_p) Cauchy-combined element-wise.
+    #[test]
+    fn run_ai_staar_b0_matches_two_run_cauchy() {
+        let n = 30;
         let m = 4;
+        let n_pops = 2;
+        let n_channels = 3;
+
+        let mut state = 0xfeedfaceu64;
+        let mut next = || {
+            state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            ((state >> 33) as f64) / ((1u64 << 31) as f64)
+        };
+
+        let mut x = Mat::zeros(n, 2);
+        for i in 0..n {
+            x[(i, 0)] = 1.0;
+            x[(i, 1)] = next() * 2.0 - 1.0;
+        }
+        let mut y = Mat::zeros(n, 1);
+        for i in 0..n {
+            y[(i, 0)] = 0.3 * x[(i, 1)] + (next() - 0.5) * 0.4;
+        }
+        let null = model::fit_glm(&y, &x);
 
         let mut g = Mat::zeros(n, m);
         for j in 0..m {
-            for i in 0..2 {
-                g[(i + j * 2, j)] = 1.0;
+            for i in 0..n {
+                if next() < 0.15 {
+                    g[(i, j)] = 1.0;
+                }
+            }
+        }
+        let group: Vec<usize> = (0..n).map(|i| if i < n / 2 { 0 } else { 1 }).collect();
+        let ancestry = AncestryInfo::new(group.clone(), n_pops, 0, 7590);
+
+        let ann: Vec<Vec<f64>> = (0..n_channels)
+            .map(|c| (0..m).map(|j| 0.2 + 0.1 * (c + j) as f64).collect())
+            .collect();
+
+        let mut pop_n = vec![0usize; n_pops];
+        for &p in &group {
+            pop_n[p] += 1;
+        }
+        let mut pop_mafs: Vec<Vec<f64>> = vec![vec![0.0; n_pops]; m];
+        for j in 0..m {
+            for i in 0..n {
+                pop_mafs[j][group[i]] += g[(i, j)];
+            }
+            for k in 0..n_pops {
+                pop_mafs[j][k] /= 2.0 * pop_n[k] as f64;
             }
         }
 
-        let ann = vec![vec![0.5; m]; 3];
+        let actual = run_ai_staar(&g, &ann, &pop_mafs, &ancestry, &null, false);
 
-        // Two populations: first 20 samples = pop 0, last 20 = pop 1
-        let ancestry = AncestryInfo {
-            group: (0..n).map(|i| if i < 20 { 0 } else { 1 }).collect(),
-            n_pops: 2,
-        };
-
-        // Population-specific MAFs: variant 0 rare in pop0 but common in pop1
-        let pop_mafs = vec![
-            vec![0.001, 0.05],
-            vec![0.005, 0.005],
-            vec![0.003, 0.003],
-            vec![0.002, 0.002],
-        ];
-
-        let mut y = Mat::zeros(n, 1);
-        for i in 0..n {
-            y[(i, 0)] = if i % 5 == 0 { 1.0 } else { 0.0 };
+        let mut a_p = vec![0.0f64; n_pops];
+        for k in 0..n_pops {
+            let mut sum = 0.0;
+            for j in 0..m {
+                let maf = pop_mafs[j][k];
+                sum += maf.min(1.0 - maf);
+            }
+            let mean = sum / m as f64;
+            a_p[k] = if mean > 0.0 {
+                score::beta_density_weight(mean, 1.0, 25.0)
+            } else {
+                0.0
+            };
         }
-        let mut x = Mat::zeros(n, 1);
+        let mafs: Vec<f64> = (0..m)
+            .map(|j| {
+                let mut mac = 0.0;
+                for i in 0..n {
+                    mac += g[(i, j)];
+                }
+                (mac / (2.0 * n as f64)).clamp(1e-10, 0.499)
+            })
+            .collect();
+
+        let r1 = score::run_staar(&g, &ann, &mafs, &null, false);
+        let mut g2 = Mat::zeros(n, m);
+        for i in 0..n {
+            let s = a_p[group[i]];
+            for j in 0..m {
+                g2[(i, j)] = s * g[(i, j)];
+            }
+        }
+        let r2 = score::run_staar(&g2, &ann, &mafs, &null, false);
+
+        let f1 = flatten_staar(&r1, n_channels);
+        let f2 = flatten_staar(&r2, n_channels);
+        assert_eq!(f1.len(), 6 * (1 + n_channels));
+        let mut aggregated = vec![0.0; f1.len()];
+        for i in 0..f1.len() {
+            aggregated[i] = stats::cauchy_combine(&[f1[i], f2[i]]);
+        }
+        let expected = unflatten_staar(&aggregated, n_channels);
+
+        assert!((actual.staar_o - expected.staar_o).abs() < 1e-12);
+        assert!((actual.acat_o - expected.acat_o).abs() < 1e-12);
+        assert!((actual.staar_b_1_25 - expected.staar_b_1_25).abs() < 1e-12);
+        assert!((actual.staar_b_1_1 - expected.staar_b_1_1).abs() < 1e-12);
+        assert!((actual.staar_s_1_25 - expected.staar_s_1_25).abs() < 1e-12);
+        assert!((actual.staar_s_1_1 - expected.staar_s_1_1).abs() < 1e-12);
+        assert!((actual.staar_a_1_25 - expected.staar_a_1_25).abs() < 1e-12);
+        assert!((actual.staar_a_1_1 - expected.staar_a_1_1).abs() < 1e-12);
+        assert!((actual.burden_1_25 - expected.burden_1_25).abs() < 1e-12);
+        assert!((actual.skat_1_1 - expected.skat_1_1).abs() < 1e-12);
+        assert_eq!(actual.per_annotation.len(), n_channels);
+        for ch in 0..n_channels {
+            for t in 0..6 {
+                assert!((actual.per_annotation[ch][t] - expected.per_annotation[ch][t]).abs() < 1e-12);
+            }
+        }
+    }
+
+    #[test]
+    fn run_ai_staar_gene_matches_dense() {
+        let n = 24;
+        let m = 3;
+        let n_pops = 2;
+        let n_channels = 2;
+
+        let mut state = 0xabcdef01u64;
+        let mut next = || {
+            state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            ((state >> 33) as f64) / ((1u64 << 31) as f64)
+        };
+        let mut x = Mat::zeros(n, 2);
         for i in 0..n {
             x[(i, 0)] = 1.0;
+            x[(i, 1)] = next() * 2.0 - 1.0;
+        }
+        let mut y = Mat::zeros(n, 1);
+        for i in 0..n {
+            y[(i, 0)] = 0.5 * x[(i, 1)] + (next() - 0.5) * 0.3;
+        }
+        let null = model::fit_glm(&y, &x);
+        let pheno_mask = vec![true; n];
+        let analysis = AnalysisVectors::from_null_model(&null, &pheno_mask);
+
+        let mut carriers: Vec<CarrierList> =
+            (0..m).map(|_| CarrierList { entries: Vec::new() }).collect();
+        for j in 0..m {
+            for i in 0..n {
+                if next() < 0.2 {
+                    carriers[j].entries.push(CarrierEntry { sample_idx: i as u32, dosage: 1 });
+                }
+            }
+            if carriers[j].entries.len() < 2 {
+                carriers[j].entries.push(CarrierEntry { sample_idx: (j * 3) as u32, dosage: 1 });
+                carriers[j].entries.push(CarrierEntry { sample_idx: (j * 3 + 1) as u32, dosage: 1 });
+            }
         }
 
-        let null = model::fit_glm(&y, &x);
-        let result = run_ai_staar(&g, &ann, &pop_mafs, &ancestry, &null, false);
+        let group: Vec<usize> = (0..n).map(|i| if i < n / 2 { 0 } else { 1 }).collect();
+        let ancestry = AncestryInfo::new(group, n_pops, 3, 7590);
+        let ann: Vec<Vec<f64>> = (0..n_channels)
+            .map(|c| (0..m).map(|j| 0.3 + 0.1 * (c + j) as f64).collect())
+            .collect();
 
-        assert!(result.staar_o >= 0.0 && result.staar_o <= 1.0);
-        assert!(result.burden_1_25 >= 0.0 && result.burden_1_25 <= 1.0);
+        let from_carriers = run_ai_staar_gene(&carriers, &analysis, &ancestry, &ann, false);
+
+        let g = sparse_score::carriers_to_dense(&carriers, &analysis);
+        let pop_mafs = pop_mafs_from_carriers(&carriers, &analysis, &ancestry);
+        let null2 = sparse_score::null_model_from_analysis(&analysis);
+        let from_dense = run_ai_staar(&g, &ann, &pop_mafs, &ancestry, &null2, false);
+
+        assert!((from_carriers.staar_o - from_dense.staar_o).abs() < 1e-12);
+        assert!((from_carriers.acat_o - from_dense.acat_o).abs() < 1e-12);
+        assert!((from_carriers.burden_1_25 - from_dense.burden_1_25).abs() < 1e-12);
+        assert!((from_carriers.skat_1_25 - from_dense.skat_1_25).abs() < 1e-12);
+    }
+
+    #[test]
+    fn flatten_unflatten_round_trip() {
+        let n_channels = 2;
+        let na = 1 + n_channels;
+        let mut flat: Vec<f64> = (0..6 * na).map(|i| 0.01 * (i as f64 + 1.0)).collect();
+        for v in flat.iter_mut() {
+            *v = v.min(0.99);
+        }
+        let result = unflatten_staar(&flat, n_channels);
+        let again = flatten_staar(&result, n_channels);
+        assert_eq!(flat.len(), again.len());
+        for i in 0..flat.len() {
+            assert!((flat[i] - again[i]).abs() < 1e-12, "mismatch at {i}");
+        }
     }
 }

--- a/src/staar/carrier/sparse_score.rs
+++ b/src/staar/carrier/sparse_score.rs
@@ -289,7 +289,7 @@ pub fn run_staar_sparse(
 
     if use_spa && !analysis.fitted_values.is_empty() {
         let g = carriers_to_dense(carriers, analysis);
-        score::run_staar(&g, annotation_matrix, mafs, &null_model_ref(analysis), use_spa)
+        score::run_staar(&g, annotation_matrix, mafs, &null_model_from_analysis(analysis), use_spa)
     } else {
         let (u, k) = score_gene_sparse(carriers, analysis);
         score::run_staar_from_sumstats(&u, &k, annotation_matrix, mafs, analysis.n_pheno)
@@ -312,9 +312,9 @@ pub fn slice_sumstats(
     (u_sub, k_sub)
 }
 
-/// Convert carrier lists to a dense faer::Mat for SPA path.
+/// Convert carrier lists to a dense faer::Mat for SPA / AI-STAAR paths.
 /// Uses vcf_to_pheno remapping to build n_pheno × m matrix.
-fn carriers_to_dense(carriers: &[CarrierList], analysis: &AnalysisVectors) -> Mat<f64> {
+pub(crate) fn carriers_to_dense(carriers: &[CarrierList], analysis: &AnalysisVectors) -> Mat<f64> {
     let m = carriers.len();
     let mut g = Mat::zeros(analysis.n_pheno, m);
     for (j, clist) in carriers.iter().enumerate() {
@@ -329,9 +329,9 @@ fn carriers_to_dense(carriers: &[CarrierList], analysis: &AnalysisVectors) -> Ma
     g
 }
 
-/// Reconstruct a NullModel reference from AnalysisVectors for the SPA path.
+/// Reconstruct a NullModel from AnalysisVectors for the SPA / AI-STAAR paths.
 /// Uses compact n_pheno-sized arrays.
-fn null_model_ref(analysis: &AnalysisVectors) -> NullModel {
+pub(crate) fn null_model_from_analysis(analysis: &AnalysisVectors) -> NullModel {
     let n = analysis.n_pheno;
     let k = analysis.k;
 

--- a/src/staar/model.rs
+++ b/src/staar/model.rs
@@ -21,6 +21,9 @@ pub struct PhenotypeData {
     /// True for VCF samples that have phenotype data. Length = n_total VCF samples.
     /// Used to expand null model residuals back to VCF-indexed arrays.
     pub pheno_mask: Vec<bool>,
+    /// Per-sample population labels and ensemble weights, when `--ancestry-col`
+    /// is set. Same row order as `y` / `x`.
+    pub ancestry: Option<staar::ancestry::AncestryInfo>,
 }
 
 /// Common aliases for the sample ID column.
@@ -105,12 +108,16 @@ fn arrow_f64(col: &dyn Array, row: usize) -> f64 {
         .unwrap_or(f64::NAN)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn load_phenotype(
     engine: &DfEngine,
     phenotype: &Path,
     covariates: &[String],
     geno: &GenotypeResult,
     trait_name: &str,
+    ancestry_col: Option<&str>,
+    ai_base_tests: usize,
+    ai_seed: u64,
     column_map: &HashMap<String, String>,
     out: &dyn Output,
 ) -> Result<PhenotypeData, FavorError> {
@@ -150,12 +157,21 @@ pub fn load_phenotype(
             .map(|c| format!("CAST(p.\"{c}\" AS DOUBLE)"))
             .collect::<Vec<_>>().join(", ")) };
 
+    let resolved_ancestry: Option<String> = match ancestry_col {
+        Some(name) => Some(resolve_column(name, &pheno_cols, column_map, "Ancestry")?),
+        None => None,
+    };
+    let ancestry_select = match resolved_ancestry.as_deref() {
+        Some(c) => format!(", CAST(p.\"{c}\" AS VARCHAR)"),
+        None => String::new(),
+    };
+
     let sample_list = geno.sample_names.iter()
         .map(|s| format!("'{s}'")).collect::<Vec<_>>().join(",");
 
     // Include ID column — we reorder rows to match genotype sample order below.
     let pheno_sql = format!(
-        "SELECT p.\"{id_col}\", CAST(p.\"{trait_col}\" AS DOUBLE) {cov_select} \
+        "SELECT p.\"{id_col}\", CAST(p.\"{trait_col}\" AS DOUBLE) {cov_select} {ancestry_select} \
          FROM _pheno p \
          WHERE p.\"{id_col}\" IN ({sample_list}) AND p.\"{trait_col}\" IS NOT NULL"
     );
@@ -163,7 +179,8 @@ pub fn load_phenotype(
     let batches = engine.collect(&pheno_sql)?;
 
     // Collect phenotype keyed by sample ID — SQL row order is irrelevant.
-    let mut pheno_map: HashMap<String, (f64, Vec<f64>)> = HashMap::new();
+    let ancestry_col_idx = 2 + n_cov;
+    let mut pheno_map: HashMap<String, (f64, Vec<f64>, Option<String>)> = HashMap::new();
     for batch in &batches {
         for row in 0..batch.num_rows() {
             let id = arrow_str(batch.column(0).as_ref(), row);
@@ -171,7 +188,13 @@ pub fn load_phenotype(
             let covs: Vec<f64> = (0..n_cov)
                 .map(|j| arrow_f64(batch.column(2 + j).as_ref(), row))
                 .collect();
-            pheno_map.insert(id, (y_val, covs));
+            let pop_label = if resolved_ancestry.is_some() {
+                let raw = arrow_str(batch.column(ancestry_col_idx).as_ref(), row);
+                if raw.is_empty() { None } else { Some(raw) }
+            } else {
+                None
+            };
+            pheno_map.insert(id, (y_val, covs, pop_label));
         }
     }
 
@@ -184,14 +207,18 @@ pub fn load_phenotype(
     let mut y_vec = Vec::with_capacity(n_total);
     let mut x_vecs: Vec<Vec<f64>> = vec![Vec::with_capacity(n_total); n_cov];
     let mut pheno_mask = Vec::with_capacity(n_total);
+    let mut pop_labels: Vec<Option<String>> = Vec::with_capacity(n_total);
     for name in &geno.sample_names {
         match pheno_map.get(name.as_str()) {
-            Some((y_val, covs)) => {
+            Some((y_val, covs, pop_label)) => {
                 y_vec.push(*y_val);
                 for (j, c) in covs.iter().enumerate() {
                     x_vecs[j].push(*c);
                 }
                 pheno_mask.push(true);
+                if resolved_ancestry.is_some() {
+                    pop_labels.push(pop_label.clone());
+                }
             }
             None => {
                 pheno_mask.push(false);
@@ -245,7 +272,47 @@ pub fn load_phenotype(
         }
     }
 
-    Ok(PhenotypeData { y, x, trait_type, n, pheno_mask })
+    let ancestry = match resolved_ancestry.as_deref() {
+        None => None,
+        Some(col) => {
+            let missing = pop_labels.iter().filter(|p| p.is_none()).count();
+            if missing > 0 {
+                return Err(FavorError::Input(format!(
+                    "{missing} samples have missing values for ancestry column '{col}'. \
+                     Remove or impute before running --ancestry-col."
+                )));
+            }
+            let mut order: Vec<String> = Vec::new();
+            let mut group: Vec<usize> = Vec::with_capacity(n);
+            for label in pop_labels.iter().flatten() {
+                let idx = order.iter().position(|l| l == label).unwrap_or_else(|| {
+                    order.push(label.clone());
+                    order.len() - 1
+                });
+                group.push(idx);
+            }
+            if order.len() < 2 {
+                return Err(FavorError::Input(format!(
+                    "Ancestry column '{col}' has only {} distinct value(s); \
+                     --ancestry-col needs at least 2 populations.",
+                    order.len()
+                )));
+            }
+            out.status(&format!(
+                "  Ancestry: {} populations ({}), AI-STAAR B={ai_base_tests}",
+                order.len(),
+                order.join(", "),
+            ));
+            Some(staar::ancestry::AncestryInfo::new(
+                group,
+                order.len(),
+                ai_base_tests,
+                ai_seed,
+            ))
+        }
+    };
+
+    Ok(PhenotypeData { y, x, trait_type, n, pheno_mask, ancestry })
 }
 
 pub fn load_known_loci(

--- a/src/staar/pipeline.rs
+++ b/src/staar/pipeline.rs
@@ -38,6 +38,11 @@ pub struct StaarConfig {
     pub window_size: u32,
     pub individual: bool,
     pub spa: bool,
+    pub ancestry_col: Option<String>,
+    /// AI-STAAR ensemble base test count B. Adds 2*(B+1) STAAR runs per gene.
+    pub ai_base_tests: usize,
+    /// AI-STAAR ensemble weight RNG seed.
+    pub ai_seed: u64,
     pub scang_params: ScangParams,
     pub known_loci: Option<PathBuf>,
     pub emit_sumstats: bool,
@@ -77,6 +82,7 @@ struct ScoringContext {
     analysis: AnalysisVectors,
     use_spa: bool,
     cache_dir: PathBuf,
+    ancestry: Option<staar::ancestry::AncestryInfo>,
 }
 
 impl<'a> StaarPipeline<'a> {
@@ -146,11 +152,20 @@ impl<'a> StaarPipeline<'a> {
             &self.config.covariates,
             &geno_for_pheno,
             primary_trait,
+            self.config.ancestry_col.as_deref(),
+            self.config.ai_base_tests,
+            self.config.ai_seed,
             &self.config.column_map,
             self.out,
         )?;
-        let (y, mut x, trait_type, n, pheno_mask) =
-            (pheno.y, pheno.x, pheno.trait_type, pheno.n, pheno.pheno_mask);
+        let (y, mut x, trait_type, n, pheno_mask, ancestry) = (
+            pheno.y,
+            pheno.x,
+            pheno.trait_type,
+            pheno.n,
+            pheno.pheno_mask,
+            pheno.ancestry,
+        );
 
         if let Some(ref loci_path) = self.config.known_loci {
             let x_cond = load_known_loci(&store.engine, &geno_for_pheno, loci_path, n, self.out)?;
@@ -219,6 +234,7 @@ impl<'a> StaarPipeline<'a> {
             analysis,
             use_spa,
             cache_dir: sc_dir,
+            ancestry,
         };
 
         // Layer 3: Score tests from cache
@@ -454,6 +470,7 @@ fn run_score_tests(
             let cache = score_cache::load_chromosome(&ctx.cache_dir, chrom_name, &variant_index)?;
             let all_entries = variant_index.all_entries();
             let use_spa = ctx.use_spa;
+            let ancestry = ctx.ancestry.as_ref();
             let n_vcf = analysis.n_vcf_total;
 
             let gene_names: Vec<&String> = cache.gene_blocks.keys().collect();
@@ -503,7 +520,10 @@ fn run_score_tests(
                                 .map(|ch| qualifying.iter().map(|&i| all_entries[gene_vcfs[i] as usize].weights.0[ch]).collect())
                                 .collect();
 
-                            let sr = if use_spa {
+                            let sr = if let Some(ai) = ancestry {
+                                let subset: Vec<_> = qualifying.iter().map(|&i| carriers[i].clone()).collect();
+                                staar::ancestry::run_ai_staar_gene(&subset, analysis, ai, &ann_matrix, use_spa)
+                            } else if use_spa {
                                 let subset: Vec<_> = qualifying.iter().map(|&i| carriers[i].clone()).collect();
                                 sparse_score::run_staar_sparse(&subset, analysis, &ann_matrix, &mafs, true)
                             } else {
@@ -546,7 +566,13 @@ fn run_score_tests(
                                 .collect())
                             .collect();
 
-                        let sr = if use_spa {
+                        let sr = if let Some(ai) = ancestry {
+                            let mask_vcfs: Vec<u32> = qualifying.iter()
+                                .map(|&l| block.variant_offsets[l])
+                                .collect();
+                            let subset = sparse_g.load_variants(&mask_vcfs);
+                            staar::ancestry::run_ai_staar_gene(&subset, analysis, ai, &ann_matrix, use_spa)
+                        } else if use_spa {
                             // SPA: load carriers from SparseG for this mask
                             let mask_vcfs: Vec<u32> = qualifying.iter()
                                 .map(|&l| block.variant_offsets[l])
@@ -615,6 +641,7 @@ fn run_score_tests(
                 &ctx.cache_dir, chrom_name, &variant_index,
             )?;
             let n_vcf = analysis.n_vcf_total;
+            let ancestry = ctx.ancestry.as_ref();
 
             let score_window = |g: &MaskGroup| -> Option<GeneResult> {
                 let m = g.variant_indices.len();
@@ -623,9 +650,6 @@ fn run_score_tests(
                 let win_globals: Vec<usize> = g.variant_indices.iter()
                     .map(|&ci| global_indices[ci])
                     .collect();
-
-                let u_win = score_cache::slice_window_u(&window_cache, &win_globals);
-                let k_win = score_cache::assemble_window_k(&window_cache, &win_globals);
 
                 let mafs: Vec<f64> = g.variant_indices.iter()
                     .map(|&ci| chrom_variants[ci].maf)
@@ -636,9 +660,17 @@ fn run_score_tests(
                         .collect())
                     .collect();
 
-                let sr = score::run_staar_from_sumstats(
-                    &u_win, &k_win, &ann_matrix, &mafs, analysis.n_pheno,
-                );
+                let sr = if let Some(ai) = ancestry {
+                    let win_vcfs: Vec<u32> = win_globals.iter().map(|&i| i as u32).collect();
+                    let carriers = sparse_g.load_variants(&win_vcfs);
+                    staar::ancestry::run_ai_staar_gene(&carriers, analysis, ai, &ann_matrix, ctx.use_spa)
+                } else {
+                    let u_win = score_cache::slice_window_u(&window_cache, &win_globals);
+                    let k_win = score_cache::assemble_window_k(&window_cache, &win_globals);
+                    score::run_staar_from_sumstats(
+                        &u_win, &k_win, &ann_matrix, &mafs, analysis.n_pheno,
+                    )
+                };
                 let cmac: u32 = mafs.iter()
                     .map(|&maf| (2.0 * maf * n_vcf as f64).round() as u32)
                     .sum();


### PR DESCRIPTION
Replaces the in-house `run_ai_staar` with a port of `STAAR/R/AI_STAAR.R`. The previous version split G per population, ran STAAR on each slice with population-specific MAFs, and Cauchy-combined the per-pop results. That is not what upstream does.

Upstream `AI_STAAR` instead generates ensemble weight matrices `pop_weights_1_1` and `pop_weights_1_25` (both `n_pops × (B+1)`, column 0 all-ones) and, for each base test `b`, builds two row-rescaled genotype matrices: `G1` with row in pop k scaled by `pop_weights_1_1[k, b]`, and `G2` with row in pop k scaled by `a_p[k] * pop_weights_1_25[k, b]` where `a_p[k] = dbeta(mean folded MAF in pop k, 1, 25)`. Standard STAAR-O runs on each rescaled G; the resulting `2*(B+1)` flat p-value vectors (length `6*(1+n_channels)`) are aggregated element-wise via Cauchy combination, and the standard STAAR omnibus structure is rebuilt from the aggregated vector.

Ensemble weights match `STAARpipeline/R/staar2aistaar_nullmodel.R`: column 0 all-ones, columns 1..=B are `|N(0,1)|` samples. R's MT seed cannot be matched bit-exact across PRNGs, so this uses a small deterministic LCG + Box-Muller — distribution and column-0 convention match upstream.

CLI: `--ai-base-tests <B>` (default 5), `--ai-seed <u64>` (default 7590). Wired through all three score sites: large-gene fallback, standard cached path, and sliding-window/SCANG.

Numeric parity against an actual R `AI_STAAR` run is still pending and noted in `docs/validation.md` — needs a paired R fixture with pre-populated `pop_weights_1_1` / `pop_weights_1_25` matrices and a shared RNG. `cargo test --bin favor` 141/141, clippy clean.

Closes #5