### PR TITLE
tier S: --threads, lazy VCF header, progress bars, parallel gene loops

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -30,6 +30,10 @@ pub struct Cli {
     /// Validate inputs and emit a JSON execution plan without doing real work
     #[arg(long, global = true, default_value_t = false)]
     pub dry_run: bool,
+
+    /// Override auto-detected thread count (otherwise SLURM/cgroup/nproc)
+    #[arg(long, global = true)]
+    pub threads: Option<usize>,
 }
 
 #[derive(Subcommand)]

--- a/src/ingest/vcf.rs
+++ b/src/ingest/vcf.rs
@@ -323,13 +323,26 @@ pub fn ingest_vcfs(
 
         let reader = open_vcf(input_path, threads)?;
         let mut vcf_reader = noodles_vcf::io::Reader::new(reader);
-        let header = vcf_reader.read_header().map_err(|e| {
-            FavorError::Input(format!(
-                "Invalid VCF header in {}: {e}",
-                input_path.display()
-            ))
-        })?;
+        {
+            let mut hr = vcf_reader.header_reader();
+            std::io::copy(&mut hr, &mut std::io::sink()).map_err(|e| {
+                FavorError::Input(format!(
+                    "Skip VCF header in {}: {e}",
+                    input_path.display()
+                ))
+            })?;
+        }
 
+        let pb = output.progress(
+            0,
+            &format!(
+                "ingesting {}",
+                input_path
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+            ),
+        );
         for result in vcf_reader.records() {
             let record = result.map_err(|e| {
                 FavorError::Analysis(format!("VCF parse error in {}: {e}", input_path.display()))
@@ -337,7 +350,6 @@ pub fn ingest_vcfs(
 
             process_record(
                 &record,
-                &header,
                 &mut writers,
                 vs_writer,
                 &schema,
@@ -348,7 +360,9 @@ pub fn ingest_vcfs(
                 &mut multiallelic_split,
                 output,
             )?;
+            pb.inc(1);
         }
+        pb.finish(&format!("{variant_count} variants ingested"));
     }
 
     // Flush and close all writers
@@ -409,7 +423,6 @@ fn get_or_create_writer<'a>(
 #[allow(clippy::too_many_arguments)]
 fn process_record(
     record: &noodles_vcf::Record,
-    _header: &noodles_vcf::Header,
     writers: &mut HashMap<&'static str, ChromWriter>,
     vs_writer: &VariantSetWriter,
     schema: &Arc<Schema>,
@@ -498,10 +511,6 @@ fn process_record(
             cw.writer
                 .write(&rb)
                 .map_err(|e| FavorError::Resource(format!("Parquet write error: {e}")))?;
-
-            if *variant_count % 1_000_000 == 0 {
-                output.status(&format!("  {} variants processed...", variant_count));
-            }
         }
     }
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,10 @@ fn main() {
     let mode = OutputMode::detect(&cli.format);
     let out = output::create(&mode);
 
+    if let Some(t) = cli.threads {
+        std::env::set_var("FAVOR_THREADS", t.to_string());
+    }
+
     let dry_run = cli.dry_run;
     let result = run(cli.command, &*out, &mode, dry_run);
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,6 +1,8 @@
 //! Output trait + implementations. All commands use this — never write stdout directly.
 
 use std::io::IsTerminal;
+use std::sync::Arc;
+use std::time::Duration;
 
 use clap::ValueEnum;
 use serde_json::json;
@@ -43,6 +45,24 @@ impl OutputMode {
     }
 }
 
+#[derive(Clone)]
+pub struct Progress(Option<Arc<indicatif::ProgressBar>>);
+
+impl Progress {
+    #[inline]
+    pub fn inc(&self, n: u64) {
+        if let Some(p) = &self.0 {
+            p.inc(n);
+        }
+    }
+
+    pub fn finish(&self, msg: &str) {
+        if let Some(p) = &self.0 {
+            p.finish_with_message(msg.to_string());
+        }
+    }
+}
+
 /// All commands use this trait for output — never write stdout directly.
 pub trait Output {
     fn status(&self, msg: &str);
@@ -51,6 +71,8 @@ pub trait Output {
     fn error(&self, err: &FavorError);
     fn result_json(&self, data: &serde_json::Value);
     fn table(&self, headers: &[&str], rows: &[Vec<String>]);
+    /// `total == 0` is a spinner (unknown length). Machine mode is a no-op.
+    fn progress(&self, total: u64, label: &str) -> Progress;
 }
 
 pub fn create(mode: &OutputMode) -> Box<dyn Output> {
@@ -83,6 +105,28 @@ impl Output for HumanOutput {
         if let Ok(json) = serde_json::to_string_pretty(data) {
             println!("{json}");
         }
+    }
+
+    fn progress(&self, total: u64, label: &str) -> Progress {
+        let pb = if total == 0 {
+            indicatif::ProgressBar::new_spinner()
+        } else {
+            indicatif::ProgressBar::new(total)
+        };
+        let style = if total == 0 {
+            indicatif::ProgressStyle::default_spinner()
+                .template("  {spinner} {msg} {pos} ({per_sec})")
+                .unwrap()
+        } else {
+            indicatif::ProgressStyle::default_bar()
+                .template("  {msg:<28} [{bar:30}] {pos}/{len} ({eta})")
+                .unwrap()
+                .progress_chars("=> ")
+        };
+        pb.set_style(style);
+        pb.set_message(label.to_string());
+        pb.enable_steady_tick(Duration::from_millis(120));
+        Progress(Some(Arc::new(pb)))
     }
 
     fn table(&self, headers: &[&str], rows: &[Vec<String>]) {
@@ -148,6 +192,10 @@ impl Output for MachineOutput {
         if let Ok(json) = serde_json::to_string(data) {
             println!("{json}");
         }
+    }
+
+    fn progress(&self, _total: u64, _label: &str) -> Progress {
+        Progress(None)
     }
 
     fn table(&self, headers: &[&str], rows: &[Vec<String>]) {

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -130,7 +130,12 @@ fn detect_memory() -> u64 {
 }
 
 fn detect_threads(config_threads: Option<usize>) -> usize {
-    // SLURM_CPUS_PER_TASK overrides everything
+    if let Ok(val) = std::env::var("FAVOR_THREADS") {
+        if let Ok(n) = val.parse::<usize>() {
+            return n;
+        }
+    }
+
     if let Ok(val) = std::env::var("SLURM_CPUS_PER_TASK") {
         if let Ok(n) = val.parse::<usize>() {
             return n;

--- a/src/staar/genotype.rs
+++ b/src/staar/genotype.rs
@@ -93,6 +93,7 @@ pub fn extract_genotypes(
         chromosomes: Vec::new(),
     };
 
+    let pb = output.progress(0, "extracting genotypes");
     for result in vcf_reader.records() {
         let record = result.map_err(|e| {
             FavorError::Analysis(format!("VCF parse error in '{}': {e}", vcf_path.display()))
@@ -100,7 +101,9 @@ pub fn extract_genotypes(
         process_record(
             &record, n_samples, &mut state, &schema, &props, &geno_dir, output,
         )?;
+        pb.inc(1);
     }
+    pb.finish(&format!("{} variants extracted", state.total_variants));
 
     flush(&mut state, &schema)?;
     if let Some(w) = state.writer.take() {
@@ -260,9 +263,6 @@ fn process_record(
 
         if state.batch.is_full() {
             flush(state, schema)?;
-            if state.total_variants % 500_000 == 0 {
-                output.status(&format!("  {} variants...", state.total_variants));
-            }
         }
     }
 

--- a/src/staar/pipeline.rs
+++ b/src/staar/pipeline.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use faer::Mat;
+use rayon::prelude::*;
 
 use crate::column::STAAR_WEIGHTS;
 use crate::data::{AnnotatedSet, VariantSet, VariantSetKind};
@@ -475,7 +476,7 @@ fn run_score_tests(
 
             let gene_names: Vec<&String> = cache.gene_blocks.keys().collect();
             let per_gene_results: Vec<Vec<(usize, GeneResult)>> = gene_names
-                .iter()
+                .par_iter()
                 .filter_map(|gene_name| {
                     let block = cache.gene_blocks.get(*gene_name)?;
                     if block.m() < 2 { return None; }

--- a/src/staar/score_cache.rs
+++ b/src/staar/score_cache.rs
@@ -26,6 +26,7 @@ use std::io::{BufReader, BufWriter, Read as IoRead, Write as IoWrite};
 use std::path::{Path, PathBuf};
 
 use faer::Mat;
+use rayon::prelude::*;
 use sha2::{Digest, Sha256};
 
 use crate::error::FavorError;
@@ -206,62 +207,55 @@ pub fn build_chromosome(
 ) -> Result<(), FavorError> {
     let n_variants = variant_index.len();
 
-    // Compute U/K per gene, scatter into chromosome-wide U vector
-    let mut u_all = vec![0.0f64; n_variants];
-    let mut gene_computed: Vec<GeneComputed> = Vec::with_capacity(variant_index.n_genes());
-
     let gene_names: Vec<String> = variant_index.gene_names().map(|s| s.to_string()).collect();
 
-    for gene_name in &gene_names {
-        let gene_vcfs = variant_index.gene_variant_vcfs(gene_name);
-        let m = gene_vcfs.len();
-        if m == 0 {
-            continue;
-        }
-
-        // Load carrier data once for all variants in this gene
-        let carriers = sparse_g.load_variants(gene_vcfs);
-        let variant_offsets: Vec<u32> = gene_vcfs.to_vec();
-        let variant_vids: Vec<Box<str>> = gene_vcfs
-            .iter()
-            .map(|&v| variant_index.get(v).vid.clone())
-            .collect();
-
-        let gc = if m > MAX_K_VARIANTS {
-            let u_values = sparse_score::compute_u_only(&carriers, analysis);
-            GeneComputed {
-                gene_name: gene_name.clone(),
-                variant_vids,
-                variant_offsets,
-                u_values,
-                k_flat: Vec::new(),
+    let mut gene_computed: Vec<GeneComputed> = gene_names
+        .par_iter()
+        .filter_map(|gene_name| {
+            let gene_vcfs = variant_index.gene_variant_vcfs(gene_name);
+            let m = gene_vcfs.len();
+            if m == 0 {
+                return None;
             }
-        } else {
-            let (u_mat, k_mat) = sparse_score::score_gene_sparse(&carriers, analysis);
-            let u_values: Vec<f64> = (0..m).map(|i| u_mat[(i, 0)]).collect();
-            let mut k_flat = vec![0.0f64; m * m];
-            for r in 0..m {
-                for c in 0..m {
-                    k_flat[r * m + c] = k_mat[(r, c)];
+            let carriers = sparse_g.load_variants(gene_vcfs);
+            let variant_offsets: Vec<u32> = gene_vcfs.to_vec();
+            let variant_vids: Vec<Box<str>> = gene_vcfs
+                .iter()
+                .map(|&v| variant_index.get(v).vid.clone())
+                .collect();
+            let (u_values, k_flat) = if m > MAX_K_VARIANTS {
+                (sparse_score::compute_u_only(&carriers, analysis), Vec::new())
+            } else {
+                let (u_mat, k_mat) = sparse_score::score_gene_sparse(&carriers, analysis);
+                let u: Vec<f64> = (0..m).map(|i| u_mat[(i, 0)]).collect();
+                let mut k = vec![0.0f64; m * m];
+                for r in 0..m {
+                    for c in 0..m {
+                        k[r * m + c] = k_mat[(r, c)];
+                    }
                 }
-            }
-            GeneComputed {
+                (u, k)
+            };
+            Some(GeneComputed {
                 gene_name: gene_name.clone(),
                 variant_vids,
                 variant_offsets,
                 u_values,
                 k_flat,
-            }
-        };
+            })
+        })
+        .collect();
 
-        // Scatter U values into chromosome-wide vector
+    // U[i] depends only on variant i, not gene context, so the many-to-many
+    // membership overlaps in this scatter are idempotent.
+    let mut u_all = vec![0.0f64; n_variants];
+    for gc in &gene_computed {
         for (local, &global) in gc.variant_offsets.iter().enumerate() {
             let gi = global as usize;
             if gi < n_variants {
                 u_all[gi] = gc.u_values[local];
             }
         }
-        gene_computed.push(gc);
     }
 
     gene_computed.sort_by(|a, b| a.gene_name.cmp(&b.gene_name));


### PR DESCRIPTION
Closes #24
Closes #19
Closes #21
Closes #20

#24: `--threads` is a global Cli flag. `main.rs` sets `FAVOR_THREADS` from it and `resource.rs::detect_threads` reads that env var ahead of `SLURM_CPUS_PER_TASK`. The six existing `detect_configured()` call sites inherit the override without any signature change.

#19: ingest was calling `read_header()` per block file and then ignoring the parsed `Header` — `process_record` had a dead `_header` param. Switched to `header_reader()` + `io::copy(sink)` which advances the reader past the header bytes without parsing samples or contigs. Drops the dead parameter from `process_record`. Matters more on UKB-scale headers (200K samples × 23 blocks).

#21: `Output` gains a `progress(total, label)` method returning a small `Progress(Option<Arc<ProgressBar>>)` wrapper. Human mode wraps indicatif, machine mode is `None` so call sites don't branch. The modulo-based status prints in `ingest/vcf.rs` and `staar/genotype.rs` are replaced with `pb.inc(1)` + `pb.finish` at the call site.

#20: `pipeline.rs::run_score_tests` and `score_cache.rs::build_chromosome` both had gene loops shaped as `iter().filter_map(...).collect()`, so the `par_iter` swap is one word plus a `use`. `build_chromosome` was an imperative for-loop with mutation; it's now pure compute → `par_iter` → serial scatter. The post-collect `sort_by(gene_name)` already existed so output bytes stay deterministic. The scatter is idempotent because `U[i]` depends only on variant `i`, not on which gene's loop computed it.

`cargo test --release` 141/141. `par_iter` doesn't perturb p-values.