### PR TITLE
audit cleanup: drop banner comments, dead code, unwrap slop

### DIFF
--- a/src/column.rs
+++ b/src/column.rs
@@ -138,8 +138,6 @@ impl std::fmt::Display for Col {
     }
 }
 
-// ── Column groups ───────────────────────────────────────────────────────
-
 /// The 11 STAAR annotation weight columns, in canonical order.
 /// This array is the single source of truth for weight column ordering.
 pub const STAAR_WEIGHTS: [Col; 11] = [
@@ -181,8 +179,6 @@ pub fn store_columns() -> Vec<Col> {
     cols.extend_from_slice(&STAAR_WEIGHTS);
     cols
 }
-
-// ── Annotation join SQL generation (Part 4) ─────────────────────────────
 
 /// A column extracted from FAVOR annotation parquet into the pipeline.
 pub struct AnnotationExtract {
@@ -414,8 +410,6 @@ pub fn gene_count_sql() -> String {
     )
 }
 
-// ── Schema contract types (Part 2) ─────────────────────────────────────
-
 /// Simplified Arrow data type for compile-time schema contracts.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ColType {
@@ -578,8 +572,6 @@ pub static INDIVIDUAL_RESULT_CONTRACT: SchemaContract = SchemaContract {
         (Col::CaddPhred, ColType::Float64),
     ],
 };
-
-// ── Tests ────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {

--- a/src/commands/annotate.rs
+++ b/src/commands/annotate.rs
@@ -113,10 +113,6 @@ fn emit_dry_run(config: &AnnotateConfig, out: &dyn Output) -> Result<(), FavorEr
     Ok(())
 }
 
-// ---------------------------------------------------------------------------
-// Core pipeline
-// ---------------------------------------------------------------------------
-
 /// Core annotate pipeline: open → validate → join → report.
 pub fn run_annotate(config: &AnnotateConfig, out: &dyn Output) -> Result<(), FavorError> {
     let input = VariantSet::open(&config.input)?;
@@ -167,10 +163,6 @@ fn validate_input(input: &VariantSet) -> Result<(), FavorError> {
     }
     Ok(())
 }
-
-// ---------------------------------------------------------------------------
-// Annotation join
-// ---------------------------------------------------------------------------
 
 struct AnnotateResult {
     output: VariantSet,
@@ -372,10 +364,6 @@ fn join_via_rsid(
     writer.scan_and_register()?;
     Ok(())
 }
-
-// ---------------------------------------------------------------------------
-// Result reporting and diagnostics
-// ---------------------------------------------------------------------------
 
 fn report_result(
     result: &AnnotateResult,

--- a/src/commands/enrich.rs
+++ b/src/commands/enrich.rs
@@ -88,10 +88,6 @@ fn emit_dry_run(config: &EnrichConfig, out: &dyn Output) -> Result<(), FavorErro
     Ok(())
 }
 
-// ---------------------------------------------------------------------------
-// Core pipeline
-// ---------------------------------------------------------------------------
-
 /// Core enrich pipeline: open → validate → resolve tissue → join tables → report.
 pub fn run_enrich(config: &EnrichConfig, out: &dyn Output) -> Result<(), FavorError> {
     let annotated = AnnotatedSet::open(&config.input)?;
@@ -143,10 +139,6 @@ pub fn run_enrich(config: &EnrichConfig, out: &dyn Output) -> Result<(), FavorEr
     Ok(())
 }
 
-// ---------------------------------------------------------------------------
-// Tissue resolution
-// ---------------------------------------------------------------------------
-
 fn resolve_tissue(
     engine: &DfEngine,
     tissue_dir: &std::path::Path,
@@ -180,10 +172,6 @@ fn resolve_tissue(
 
     Ok(resolved)
 }
-
-// ---------------------------------------------------------------------------
-// Enrichment join
-// ---------------------------------------------------------------------------
 
 fn run_enrichment(
     annotated: &AnnotatedSet,
@@ -271,10 +259,6 @@ fn run_enrichment(
 
     Ok(tables_written)
 }
-
-// ---------------------------------------------------------------------------
-// Reporting
-// ---------------------------------------------------------------------------
 
 fn write_meta(
     tables_written: &[(String, i64)],

--- a/src/commands/ingest.rs
+++ b/src/commands/ingest.rs
@@ -149,10 +149,6 @@ fn run_ingest_dry(config: &IngestConfig, out: &dyn Output) -> Result<(), FavorEr
     Ok(())
 }
 
-// ---------------------------------------------------------------------------
-// Core pipeline
-// ---------------------------------------------------------------------------
-
 /// Core ingest pipeline: detect → validate → ingest → report.
 pub fn run_ingest(config: &IngestConfig, out: &dyn Output) -> Result<(), FavorError> {
     let first = &config.inputs[0];
@@ -169,10 +165,6 @@ pub fn run_ingest(config: &IngestConfig, out: &dyn Output) -> Result<(), FavorEr
     }
     ingest_tabular(config, &analysis, out)
 }
-
-// ---------------------------------------------------------------------------
-// Validation
-// ---------------------------------------------------------------------------
 
 fn validate_all_same_format(
     inputs: &[PathBuf],
@@ -194,10 +186,6 @@ fn validate_all_same_format(
     }
     Ok(())
 }
-
-// ---------------------------------------------------------------------------
-// VCF ingestion
-// ---------------------------------------------------------------------------
 
 fn ingest_vcf(config: &IngestConfig, out: &dyn Output) -> Result<(), FavorError> {
     let first = &config.inputs[0];
@@ -269,10 +257,6 @@ fn ingest_vcf(config: &IngestConfig, out: &dyn Output) -> Result<(), FavorError>
     Ok(())
 }
 
-// ---------------------------------------------------------------------------
-// SQL script emission
-// ---------------------------------------------------------------------------
-
 fn emit_sql_script(
     config: &IngestConfig,
     analysis: &ingest::Analysis,
@@ -306,10 +290,6 @@ fn emit_sql_script(
 
     Ok(())
 }
-
-// ---------------------------------------------------------------------------
-// Tabular / Parquet ingestion
-// ---------------------------------------------------------------------------
 
 fn ingest_tabular(
     config: &IngestConfig,
@@ -393,10 +373,6 @@ fn register_tabular_inputs(
     }
     Ok(())
 }
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
 
 fn apply_build_override(
     analysis: &mut ingest::Analysis,

--- a/src/commands/meta_staar.rs
+++ b/src/commands/meta_staar.rs
@@ -101,10 +101,6 @@ fn emit_dry_run(config: &MetaStaarConfig, out: &dyn Output) -> Result<(), FavorE
     Ok(())
 }
 
-// ---------------------------------------------------------------------------
-// Core pipeline
-// ---------------------------------------------------------------------------
-
 /// Core meta-STAAR pipeline: load studies → merge → score → write → report.
 pub fn run_meta_staar(config: &MetaStaarConfig, out: &dyn Output) -> Result<(), FavorError> {
     let studies = staar::meta::load_studies(&config.study_dirs)?;
@@ -164,10 +160,6 @@ fn setup_resources(
     Ok(resources)
 }
 
-// ---------------------------------------------------------------------------
-// Per-chromosome meta-analysis
-// ---------------------------------------------------------------------------
-
 fn run_all_chromosomes(
     studies: &[staar::meta::StudyHandle],
     config: &MetaStaarConfig,
@@ -207,7 +199,6 @@ fn run_all_chromosomes(
                         group,
                         &meta_variants,
                         studies,
-                        chrom,
                         &segment_cache,
                     )
                 })
@@ -306,10 +297,6 @@ fn discover_chromosomes(study_dir: &std::path::Path) -> Vec<String> {
     chroms
 }
 
-// ---------------------------------------------------------------------------
-// Summary report
-// ---------------------------------------------------------------------------
-
 fn generate_summary(
     studies: &[staar::meta::StudyHandle],
     results: &[(MaskType, Vec<GeneResult>)],
@@ -338,10 +325,6 @@ fn generate_summary(
     }
 }
 
-// ---------------------------------------------------------------------------
-// Result writing
-// ---------------------------------------------------------------------------
-
 fn write_meta_results(
     all_mask_results: &[(MaskType, Vec<GeneResult>)],
     output_dir: &std::path::Path,
@@ -350,7 +333,7 @@ fn write_meta_results(
     out.status("Writing MetaSTAAR results...");
     let channels: Vec<&str> = STAAR_WEIGHTS
         .iter()
-        .map(|c| c.weight_display_name().unwrap())
+        .map(|c| c.weight_display_name().expect("STAAR_WEIGHTS entries have display names"))
         .collect();
 
     for (mask_type, results) in all_mask_results {

--- a/src/commands/staar.rs
+++ b/src/commands/staar.rs
@@ -215,18 +215,18 @@ fn emit_dry_run(config: &StaarConfig, out: &dyn Output) -> Result<(), FavorError
         &config.annotations,
     );
 
-    let cache_status = if probe_result.hit { "hit" } else { "miss" };
-    let store_info = if probe_result.hit {
-        // hit == true guarantees manifest is Some
-        let m = probe_result.manifest.as_ref().unwrap();
-        json!({
-            "store_path": probe_result.store_dir.to_string_lossy(),
-            "store_variants": m.n_variants,
-            "store_samples": m.n_samples,
-            "created_at": m.created_at,
-        })
-    } else {
-        json!(null)
+    let (cache_status, store_info, recommended_bytes) = match &probe_result.manifest {
+        Some(m) => (
+            "hit",
+            json!({
+                "store_path": probe_result.store_dir.to_string_lossy(),
+                "store_variants": m.n_variants,
+                "store_samples": m.n_samples,
+                "created_at": m.created_at,
+            }),
+            16 * GB,
+        ),
+        None => ("miss", json!(null), recommended.max(8 * GB)),
     };
 
     let plan = commands::DryRunPlan {
@@ -245,17 +245,9 @@ fn emit_dry_run(config: &StaarConfig, out: &dyn Output) -> Result<(), FavorError
         }),
         memory: commands::MemoryEstimate {
             minimum: "4G".into(),
-            recommended: commands::human_bytes(if probe_result.hit {
-                (16 * GB).max(8 * GB)
-            } else {
-                recommended.max(8 * GB)
-            }),
+            recommended: commands::human_bytes(recommended_bytes),
             minimum_bytes: 4 * GB,
-            recommended_bytes: if probe_result.hit {
-                16 * GB
-            } else {
-                recommended.max(8 * GB)
-            },
+            recommended_bytes,
         },
         output_path: config.output_dir.to_string_lossy().into(),
     };

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -623,10 +623,6 @@ impl AnnotationDb {
     }
 }
 
-// ---------------------------------------------------------------------------
-// AnnotatedSet (was AnnotatedVariantSet — typed annotated output)
-// ---------------------------------------------------------------------------
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AnnotatedSetMeta {
     pub source: String,
@@ -716,10 +712,6 @@ impl AnnotatedSet {
     }
 }
 
-// ---------------------------------------------------------------------------
-// EnrichedSet (annotated + tissue overlays)
-// ---------------------------------------------------------------------------
-
 #[allow(dead_code)] // enrichment pipeline (v0.2.0)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EnrichedSetMeta {
@@ -753,10 +745,6 @@ impl EnrichedSet {
         &self.meta.tissue
     }
 }
-
-// ---------------------------------------------------------------------------
-// TissueTable — typed enrichment table variant
-// ---------------------------------------------------------------------------
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum TissueTable {
@@ -847,10 +835,6 @@ impl TissueTable {
         }
     }
 }
-
-// ---------------------------------------------------------------------------
-// TissueDb — manages available tissue enrichment tables
-// ---------------------------------------------------------------------------
 
 pub struct TissueDb {
     root: PathBuf,

--- a/src/ingest/format.rs
+++ b/src/ingest/format.rs
@@ -143,10 +143,6 @@ impl FormatHandler for ParquetHandler {
     }
 }
 
-// ---------------------------------------------------------------------------
-// TsvHandler
-// ---------------------------------------------------------------------------
-
 pub struct TsvHandler;
 
 impl FormatHandler for TsvHandler {
@@ -190,10 +186,6 @@ impl FormatHandler for TsvHandler {
     }
 }
 
-// ---------------------------------------------------------------------------
-// CsvHandler
-// ---------------------------------------------------------------------------
-
 pub struct CsvHandler;
 
 impl FormatHandler for CsvHandler {
@@ -233,10 +225,6 @@ impl FormatHandler for CsvHandler {
         Some(Delimiter::Comma)
     }
 }
-
-// ---------------------------------------------------------------------------
-// FormatRegistry
-// ---------------------------------------------------------------------------
 
 pub struct FormatRegistry {
     handlers: Vec<Box<dyn FormatHandler>>,

--- a/src/ingest/mod.rs
+++ b/src/ingest/mod.rs
@@ -396,7 +396,6 @@ pub fn analyze(path: &Path) -> Result<Analysis, FavorError> {
     }
 }
 
-// ── Column alias map ────────────────────────────────────────────────────────
 // THE single source of truth for GWAS column name normalization.
 
 /// (lowercased_input_name, canonical_output_name)
@@ -500,7 +499,6 @@ pub fn map_columns(raw_columns: &[String]) -> (Vec<ColumnMapping>, Vec<Ambiguity
     map_columns_with(raw_columns, ALIASES, AMBIGUOUS_ALLELE_COLS)
 }
 
-// ── Column resolver ─────────────────────────────────────────────────────────
 // Structured API over the ALIASES map: resolve input columns to canonical names
 // and report what's missing, ambiguous, or unmapped.
 
@@ -615,7 +613,6 @@ fn map_columns_with(
     (mapped, ambiguous, unmapped)
 }
 
-// ── Column contracts ────────────────────────────────────────────────────────
 // Upfront schema validation: every command checks required columns before compute.
 
 pub struct ColumnRequirement {

--- a/src/ingest/vcf.rs
+++ b/src/ingest/vcf.rs
@@ -34,12 +34,11 @@ pub fn open_vcf(path: &Path, threads: usize) -> Result<Box<dyn BufRead + Send>, 
         .map_err(|e| FavorError::Input(format!("Cannot open '{}': {e}", path.display())))?;
 
     if is_bgzf {
-        // threads.max(1) is always >= 1, so NonZeroUsize::new cannot fail
-        let workers = NonZeroUsize::new(threads.max(1)).unwrap();
+        let workers = NonZeroUsize::new(threads.max(1))
+            .expect("threads.max(1) >= 1");
         let bgzf = noodles_bgzf::reader::Builder::default()
             .set_worker_count(workers)
             .build_from_reader(file);
-        // noodles_bgzf::Reader implements BufRead — do not double-buffer.
         Ok(Box::new(bgzf))
     } else {
         Ok(Box::new(BufReader::with_capacity(256 * 1024, file)))
@@ -398,25 +397,24 @@ fn get_or_create_writer<'a>(
     batch_size: usize,
     output: &dyn Output,
 ) -> Result<&'a mut ChromWriter, FavorError> {
-    if !writers.contains_key(chrom) {
-        output.status(&format!("  chr{chrom}..."));
-        let path = vs_writer.chrom_path(chrom)?;
-        let f = File::create(&path).map_err(|e| {
-            FavorError::Resource(format!("Cannot create '{}': {e}", path.display()))
-        })?;
-        let w = ArrowWriter::try_new(f, schema.clone(), Some(props.clone()))
-            .map_err(|e| FavorError::Resource(format!("Parquet writer init: {e}")))?;
-        writers.insert(
-            chrom,
-            ChromWriter {
+    use std::collections::hash_map::Entry;
+    match writers.entry(chrom) {
+        Entry::Occupied(e) => Ok(e.into_mut()),
+        Entry::Vacant(e) => {
+            output.status(&format!("  chr{chrom}..."));
+            let path = vs_writer.chrom_path(chrom)?;
+            let f = File::create(&path).map_err(|err| {
+                FavorError::Resource(format!("Cannot create '{}': {err}", path.display()))
+            })?;
+            let w = ArrowWriter::try_new(f, schema.clone(), Some(props.clone()))
+                .map_err(|err| FavorError::Resource(format!("Parquet writer init: {err}")))?;
+            Ok(e.insert(ChromWriter {
                 batch: BatchBuilder::new(batch_size),
                 writer: w,
                 count: 0,
-            },
-        );
+            }))
+        }
     }
-    // Just inserted above if missing, so key is guaranteed present
-    Ok(writers.get_mut(chrom).unwrap())
 }
 
 /// Process a single VCF record — split multi-allelics, normalize, route to per-chrom writer.

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -85,110 +85,81 @@ impl Resources {
 /// SLURM allocation in bytes. Uses 95% — leaves headroom for slurmstepd + kernel.
 fn slurm_memory() -> Option<u64> {
     let val = std::env::var("SLURM_MEM_PER_NODE").ok()?;
-    let mb = val.trim_end_matches('M').parse::<u64>().ok()?;
+    let mb: u64 = val.trim_end_matches('M').parse().ok()?;
     Some(mb * 1024 * 1024 * 95 / 100)
 }
 
-/// Auto-detect available memory. 90% of detected — leaves room for OS.
-fn detect_memory() -> u64 {
-    if let Some(bytes) = slurm_memory() {
-        return bytes;
-    }
-
-    // cgroup memory limit (login nodes with resource limits)
-    for path in &[
+/// cgroup memory limit, if any. 90% of the limit.
+fn cgroup_memory() -> Option<u64> {
+    const PATHS: &[&str] = &[
         "/sys/fs/cgroup/memory/memory.limit_in_bytes",
         "/sys/fs/cgroup/memory.max",
-    ] {
-        if let Ok(content) = std::fs::read_to_string(path) {
-            let trimmed = content.trim();
-            if trimmed != "max" && trimmed != "9223372036854771712" {
-                if let Ok(bytes) = trimmed.parse::<u64>() {
-                    if bytes < 1024 * 1024 * 1024 * 1024 {
-                        return bytes * 90 / 100;
-                    }
-                }
-            }
+    ];
+    PATHS.iter().find_map(|p| {
+        let content = std::fs::read_to_string(p).ok()?;
+        let trimmed = content.trim();
+        if trimmed == "max" || trimmed == "9223372036854771712" {
+            return None;
         }
-    }
+        let bytes: u64 = trimmed.parse().ok()?;
+        // Reject implausibly large values (1 TiB ceiling on cgroup-reported memory).
+        (bytes < 1024 * 1024 * 1024 * 1024).then_some(bytes * 90 / 100)
+    })
+}
 
-    // /proc/meminfo
-    if let Ok(content) = std::fs::read_to_string("/proc/meminfo") {
-        for line in content.lines() {
-            if line.starts_with("MemAvailable:") {
-                let parts: Vec<&str> = line.split_whitespace().collect();
-                if let Some(kb_str) = parts.get(1) {
-                    if let Ok(kb) = kb_str.parse::<u64>() {
-                        return kb * 1024 * 90 / 100;
-                    }
-                }
-            }
-        }
-    }
+/// /proc/meminfo MemAvailable. 90% to leave room for OS.
+fn meminfo_memory() -> Option<u64> {
+    let content = std::fs::read_to_string("/proc/meminfo").ok()?;
+    let kb: u64 = content
+        .lines()
+        .find_map(|l| l.strip_prefix("MemAvailable:"))?
+        .split_whitespace()
+        .next()?
+        .parse()
+        .ok()?;
+    Some(kb * 1024 * 90 / 100)
+}
 
-    4 * 1024 * 1024 * 1024
+fn detect_memory() -> u64 {
+    slurm_memory()
+        .or_else(cgroup_memory)
+        .or_else(meminfo_memory)
+        .unwrap_or(4 * 1024 * 1024 * 1024)
+}
+
+fn env_usize(name: &str) -> Option<usize> {
+    std::env::var(name).ok()?.parse().ok()
+}
+
+fn cgroup_threads() -> Option<usize> {
+    let q: i64 = std::fs::read_to_string("/sys/fs/cgroup/cpu/cpu.cfs_quota_us")
+        .ok()?
+        .trim()
+        .parse()
+        .ok()?;
+    let p: i64 = std::fs::read_to_string("/sys/fs/cgroup/cpu/cpu.cfs_period_us")
+        .ok()?
+        .trim()
+        .parse()
+        .ok()?;
+    (q > 0 && p > 0).then(|| ((q / p).max(1)) as usize)
 }
 
 fn detect_threads(config_threads: Option<usize>) -> usize {
-    if let Ok(val) = std::env::var("FAVOR_THREADS") {
-        if let Ok(n) = val.parse::<usize>() {
-            return n;
-        }
-    }
-
-    if let Ok(val) = std::env::var("SLURM_CPUS_PER_TASK") {
-        if let Ok(n) = val.parse::<usize>() {
-            return n;
-        }
-    }
-
-    // Config override
-    if let Some(n) = config_threads {
-        return n;
-    }
-
-    // cgroup cpu quota
-    if let Ok(quota) = std::fs::read_to_string("/sys/fs/cgroup/cpu/cpu.cfs_quota_us") {
-        if let Ok(period) = std::fs::read_to_string("/sys/fs/cgroup/cpu/cpu.cfs_period_us") {
-            if let (Ok(q), Ok(p)) = (quota.trim().parse::<i64>(), period.trim().parse::<i64>()) {
-                if q > 0 && p > 0 {
-                    return (q / p).max(1) as usize;
-                }
-            }
-        }
-    }
-
-    // nproc
-    std::thread::available_parallelism()
-        .map(|n| n.get())
-        .unwrap_or(4)
+    env_usize("FAVOR_THREADS")
+        .or_else(|| env_usize("SLURM_CPUS_PER_TASK"))
+        .or(config_threads)
+        .or_else(cgroup_threads)
+        .unwrap_or_else(|| std::thread::available_parallelism().map(|n| n.get()).unwrap_or(4))
 }
 
 fn detect_temp(config: Option<&ResourceConfig>) -> PathBuf {
-    // Config override is highest priority
-    if let Some(cfg) = config {
-        if !cfg.temp_dir.is_empty() {
-            let p = PathBuf::from(&cfg.temp_dir);
-            if p.exists() {
-                return p;
-            }
-        }
-    }
+    let existing = |s: &str| (!s.is_empty()).then(|| PathBuf::from(s)).filter(|p| p.exists());
 
-    for var in &["TMPDIR", "SCRATCH", "LOCAL_SCRATCH"] {
-        if let Ok(val) = std::env::var(var) {
-            let p = PathBuf::from(&val);
-            if p.exists() {
-                return p;
-            }
-        }
-    }
-
-    // /scratch if exists
-    let scratch = PathBuf::from("/scratch");
-    if scratch.exists() {
-        return scratch;
-    }
-
-    std::env::temp_dir()
+    config
+        .and_then(|c| existing(&c.temp_dir))
+        .or_else(|| ["TMPDIR", "SCRATCH", "LOCAL_SCRATCH"].iter()
+            .find_map(|v| std::env::var(v).ok().and_then(|s| existing(&s))))
+        .or_else(|| existing("/scratch"))
+        .unwrap_or_else(std::env::temp_dir)
 }

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -116,28 +116,17 @@ fn render_init_template(config: &Config, probe: &DirProbe) -> String {
 }
 
 fn build_pack_list(config: &Config, probe: &DirProbe) -> String {
-    let mut lines = Vec::new();
-    for pack in Pack::all() {
-        if pack.always_installed {
-            continue;
-        }
-        let installed = config.data.packs.contains(&pack.id.to_string())
-            || pack
-                .tables
-                .iter()
-                .any(|t| probe.tissue_tables.contains(&t.to_string()));
-        if installed {
-            lines.push(format!(
-                "- **{}** ({}): {}",
-                pack.id, pack.size_human, pack.description
-            ));
-        }
-    }
+    let lines: Vec<String> = Pack::all()
+        .iter()
+        .filter(|p| !p.always_installed)
+        .filter(|p| {
+            config.data.packs.contains(&p.id.to_string())
+                || p.tables.iter().any(|t| probe.tissue_tables.contains(&t.to_string()))
+        })
+        .map(|p| format!("- **{}** ({}): {}", p.id, p.size_human, p.description))
+        .collect();
     if lines.is_empty() {
-        lines.push(
-            "- No optional packs. Run `favor data pull --pack <id>` then `favor init --force`."
-                .to_string(),
-        );
+        return "- No optional packs. Run `favor data pull --pack <id>` then `favor init --force`.".into();
     }
     lines.join("\n")
 }

--- a/src/setup/tui.rs
+++ b/src/setup/tui.rs
@@ -686,10 +686,6 @@ fn draw_dir_browser(frame: &mut Frame, state: &mut DirBrowserState) {
     frame.render_widget(verdict, right_layout[2]);
 }
 
-// ---------------------------------------------------------------------------
-// Pack selector
-// ---------------------------------------------------------------------------
-
 /// Interactive multi-select for add-on packs.
 /// `installed` contains pack IDs already present on disk — shown as pre-checked with "(installed)".
 /// Returns list of selected pack IDs, or None if cancelled.
@@ -861,10 +857,6 @@ fn draw_pack_selector(
     frame.render_widget(help, layout[4]);
 }
 
-// ---------------------------------------------------------------------------
-// Environment selector
-// ---------------------------------------------------------------------------
-
 struct EnvOption {
     env: Environment,
     label: &'static str,
@@ -971,10 +963,6 @@ fn draw_environment(frame: &mut Frame, selected: usize) {
         .style(Style::default().fg(Color::DarkGray));
     frame.render_widget(help, layout[3]);
 }
-
-// ---------------------------------------------------------------------------
-// Memory budget selector
-// ---------------------------------------------------------------------------
 
 struct MemoryPreset {
     label: &'static str,

--- a/src/staar/carrier/encoding.rs
+++ b/src/staar/carrier/encoding.rs
@@ -6,10 +6,6 @@
 
 use std::io::{self, Write};
 
-// ═══════════════════════════════════════════════════════════════════════
-// sparse_g.bin
-// ═══════════════════════════════════════════════════════════════════════
-
 pub const SPARSE_G_MAGIC: [u8; 8] = *b"FAVORG\x03\0";
 pub const SPARSE_G_VERSION: u16 = 3;
 pub const SPARSE_G_HEADER_SIZE: usize = 64;
@@ -80,12 +76,15 @@ impl SparseGHeader {
         if version != SPARSE_G_VERSION {
             return Err("unsupported sparse_g version");
         }
+        // Header length checked above; all slice→array conversions are infallible.
+        let read_u32 = |off: usize| u32::from_le_bytes(bytes[off..off + 4].try_into().unwrap());
+        let read_u64 = |off: usize| u64::from_le_bytes(bytes[off..off + 8].try_into().unwrap());
         Ok(Self {
-            n_samples: u32::from_le_bytes(bytes[10..14].try_into().unwrap()),
-            n_variants: u32::from_le_bytes(bytes[14..18].try_into().unwrap()),
-            flags: u32::from_le_bytes(bytes[18..22].try_into().unwrap()),
-            total_carriers: u64::from_le_bytes(bytes[22..30].try_into().unwrap()),
-            offsets_start: u64::from_le_bytes(bytes[30..38].try_into().unwrap()),
+            n_samples: read_u32(10),
+            n_variants: read_u32(14),
+            flags: read_u32(18),
+            total_carriers: read_u64(22),
+            offsets_start: read_u64(30),
         })
     }
 }

--- a/src/staar/carrier/reader.rs
+++ b/src/staar/carrier/reader.rs
@@ -243,10 +243,6 @@ impl VariantIndex {
     }
 }
 
-// ═══════════════════════════════════════════════════════════════════════
-// Loaders
-// ═══════════════════════════════════════════════════════════════════════
-
 fn load_variant_entries(chrom_dir: &Path) -> Result<Vec<VariantIndexEntry>, FavorError> {
     use arrow::array::{BooleanArray, Float64Array, Int32Array, StringArray, UInt32Array};
 
@@ -422,10 +418,6 @@ fn load_membership(chrom_dir: &Path) -> Result<HashMap<String, Vec<u32>>, FavorE
 
     Ok(gene_variants)
 }
-
-// ═══════════════════════════════════════════════════════════════════════
-// Tests — alignment invariants
-// ═══════════════════════════════════════════════════════════════════════
 
 #[cfg(test)]
 mod tests {

--- a/src/staar/carrier/sparse_score.rs
+++ b/src/staar/carrier/sparse_score.rs
@@ -409,7 +409,6 @@ pub fn slice_sumstats_flat(
     Mat::from_fn(s, s, |i, j| k_flat[indices[i] * m + indices[j]])
 }
 
-// ═══════════════════════════════════════════════════════════════════════
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/staar/masks.rs
+++ b/src/staar/masks.rs
@@ -167,10 +167,6 @@ pub fn build_noncoding_masks(
     build_masks_from_registry(variants, NONCODING_MASKS, min_variants)
 }
 
-// ---------------------------------------------------------------------------
-// SCANG: data-adaptive variable-size scanning windows (formerly scang.rs)
-// ---------------------------------------------------------------------------
-
 /// SCANG parameters: data-adaptive variable-size scanning windows.
 pub struct ScangParams {
     pub lmin: usize,

--- a/src/staar/meta.rs
+++ b/src/staar/meta.rs
@@ -563,7 +563,6 @@ pub fn meta_score_gene(
     group: &MaskGroup,
     meta_variants: &[MetaVariant],
     studies: &[StudyHandle],
-    _chrom: &str,
     segment_cache: &HashMap<(usize, i32), SegmentCov>,
 ) -> Option<GeneResult> {
     let indices: Vec<usize> = group
@@ -686,10 +685,6 @@ fn parse_study_segments(s: &str) -> Vec<(usize, i32)> {
     }
     result
 }
-
-// ──────────────────────────────────────────────────────────────────────────────
-// Summary statistics export (formerly sumstats.rs)
-// ──────────────────────────────────────────────────────────────────────────────
 
 const SEGMENT_BP: u32 = 500_000;
 const MAX_SEGMENT_VARIANTS: usize = 2000;

--- a/src/staar/output.rs
+++ b/src/staar/output.rs
@@ -23,10 +23,6 @@ use crate::types::AnnotatedVariant;
 use super::model::NullModel;
 use super::{GeneResult, MaskType, TraitType};
 
-// ===========================================================================
-// Result writing (parquet)
-// ===========================================================================
-
 pub fn write_individual_results(
     pvals: &[(usize, f64)],
     variants: &[AnnotatedVariant],
@@ -133,7 +129,7 @@ pub fn write_results(
 
     let channels: Vec<&str> = STAAR_WEIGHTS
         .iter()
-        .map(|c| c.weight_display_name().unwrap())
+        .map(|c| c.weight_display_name().expect("STAAR_WEIGHTS entries have display names"))
         .collect();
     let n_channels = channels.len();
 
@@ -340,10 +336,6 @@ pub fn write_results(
     out.result_json(&meta);
     Ok(())
 }
-
-// ===========================================================================
-// Interactive HTML summary report (Plotly.js)
-// ===========================================================================
 
 /// Chromosome sizes (hg38, bp) for Manhattan plot layout.
 const CHROMS: &[(&str, u64)] = &[
@@ -557,10 +549,6 @@ function filterTable() {{
     Ok(())
 }
 
-// ---------------------------------------------------------------------------
-// Data collection
-// ---------------------------------------------------------------------------
-
 fn collect_plot_genes(results: &[(MaskType, Vec<GeneResult>)]) -> Vec<PlotGene> {
     let offsets = chrom_offsets();
     let mut genes = Vec::new();
@@ -612,10 +600,6 @@ fn collect_pvalues(results: &[(MaskType, Vec<GeneResult>)]) -> Vec<f64> {
         .filter(|p| p.is_finite() && *p > 0.0 && *p <= 1.0)
         .collect()
 }
-
-// ---------------------------------------------------------------------------
-// Plotly JSON trace generators
-// ---------------------------------------------------------------------------
 
 fn manhattan_traces(genes: &[PlotGene]) -> String {
     // Group by chromosome for alternating colors

--- a/src/staar/pipeline.rs
+++ b/src/staar/pipeline.rs
@@ -24,10 +24,6 @@ use crate::staar::{self, GeneResult, MaskCategory, MaskType, TraitType};
 use crate::resource::Resources;
 use crate::types::{AnnotatedVariant, Chromosome};
 
-// ---------------------------------------------------------------------------
-// Config
-// ---------------------------------------------------------------------------
-
 pub struct StaarConfig {
     pub genotypes: PathBuf,
     pub phenotype: PathBuf,
@@ -68,10 +64,6 @@ impl StaarConfig {
 }
 
 pub type ResultSet = Vec<(MaskType, Vec<GeneResult>)>;
-
-// ---------------------------------------------------------------------------
-// Pipeline
-// ---------------------------------------------------------------------------
 
 pub struct StaarPipeline<'a> {
     config: StaarConfig,
@@ -307,10 +299,6 @@ impl<'a> StaarPipeline<'a> {
 
 }
 
-// ---------------------------------------------------------------------------
-// Layer 2: Per-phenotype score cache
-// ---------------------------------------------------------------------------
-
 #[allow(clippy::too_many_arguments)]
 fn ensure_score_cache(
     store_dir: &Path,
@@ -346,10 +334,6 @@ fn ensure_score_cache(
     Ok(dir)
 }
 
-// ---------------------------------------------------------------------------
-// Pipeline (continued)
-// ---------------------------------------------------------------------------
-
 impl<'a> StaarPipeline<'a> {
     fn score_all(
         &self,
@@ -366,10 +350,6 @@ impl<'a> StaarPipeline<'a> {
         )
     }
 }
-
-// ---------------------------------------------------------------------------
-// Variant loading — single path through VariantIndex
-// ---------------------------------------------------------------------------
 
 use crate::staar::carrier::VariantIndex;
 
@@ -392,10 +372,6 @@ fn load_rare_variants(
     }
     Ok(all)
 }
-
-// ---------------------------------------------------------------------------
-// Scoring — sparse G + aligned variant vectors
-// ---------------------------------------------------------------------------
 
 type MaskPredicate = fn(&AnnotatedVariant) -> bool;
 

--- a/src/staar/score.rs
+++ b/src/staar/score.rs
@@ -461,10 +461,6 @@ fn nan_result() -> StaarResult {
     }
 }
 
-// ═══════════════════════════════════════════════════════════════════════
-// Beta density weights
-// ═══════════════════════════════════════════════════════════════════════
-
 /// Beta density weight: dbeta(maf, a1, a2).
 ///
 /// For beta(1,25): upweights ultra-rare variants (MAF near 0).

--- a/src/staar/score_cache.rs
+++ b/src/staar/score_cache.rs
@@ -45,10 +45,6 @@ const GENE_NAME_LEN: usize = 32;
 /// Layer 3 falls back to carrier store for these genes.
 const MAX_K_VARIANTS: usize = 2000;
 
-// ═══════════════════════════════════════════════════════════════════════
-// Types
-// ═══════════════════════════════════════════════════════════════════════
-
 /// K matrix for one gene, with explicit mapping to chromosome-wide indices.
 pub struct GeneKBlock {
     /// Maps local index 0..m → chromosome-wide VariantIndex position.
@@ -77,10 +73,6 @@ pub struct ChromScoreCache {
     /// Per-gene K blocks with explicit variant linkage.
     pub gene_blocks: HashMap<String, GeneKBlock>,
 }
-
-// ═══════════════════════════════════════════════════════════════════════
-// Cache key
-// ═══════════════════════════════════════════════════════════════════════
 
 /// SHA-256 of (store_key, trait_name, sorted covariates, known_loci path).
 /// Invalidated by: new VCF, new annotations, different trait, different covariates,
@@ -114,10 +106,6 @@ pub fn cache_key(
 pub fn cache_dir(store_dir: &Path, key: &str) -> PathBuf {
     store_dir.join("score_cache").join(key)
 }
-
-// ═══════════════════════════════════════════════════════════════════════
-// Probe — validate existing cache
-// ═══════════════════════════════════════════════════════════════════════
 
 /// Check if a valid score cache exists for all chromosomes in the manifest.
 /// Validates file existence AND header consistency (not just existence).
@@ -178,10 +166,6 @@ fn validate_header(path: &Path) -> Result<(u32, u32), FavorError> {
 
     Ok((n_variants, n_genes))
 }
-
-// ═══════════════════════════════════════════════════════════════════════
-// Build — compute U/K for all genes, write to disk
-// ═══════════════════════════════════════════════════════════════════════
 
 /// Intermediate result from per-gene computation.
 struct GeneComputed {
@@ -359,10 +343,6 @@ pub fn build_chromosome(
     Ok(())
 }
 
-// ═══════════════════════════════════════════════════════════════════════
-// Load — read cached scores from disk
-// ═══════════════════════════════════════════════════════════════════════
-
 /// Load all cached scores for one chromosome.
 /// Vid strings on disk are resolved to current VariantIndex positions at load time.
 pub fn load_chromosome(
@@ -508,10 +488,6 @@ pub fn load_chromosome(
     Ok(ChromScoreCache { u_all, gene_blocks })
 }
 
-// ═══════════════════════════════════════════════════════════════════════
-// Window K assembly — for SCANG and sliding windows
-// ═══════════════════════════════════════════════════════════════════════
-
 /// Assemble K matrix for a window spanning potentially multiple genes.
 ///
 /// Returns block-diagonal K: within-gene terms from cached K blocks,
@@ -574,7 +550,6 @@ pub fn slice_window_u(cache: &ChromScoreCache, global_indices: &[usize]) -> Mat<
     })
 }
 
-// ═══════════════════════════════════════════════════════════════════════
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/staar/sparse_g.rs
+++ b/src/staar/sparse_g.rs
@@ -58,13 +58,11 @@ impl SparseG {
             )));
         }
 
-        // Read the offsets table
-        let mut offsets = Vec::with_capacity(n_variants);
-        for i in 0..n_variants {
-            let base = offsets_start + i * 8;
-            let val = u64::from_le_bytes(mmap[base..base + 8].try_into().unwrap());
-            offsets.push(val);
-        }
+        // Length checked above; chunks_exact(8) yields infallible 8-byte slices.
+        let offsets: Vec<u64> = mmap[offsets_start..offsets_start + offsets_bytes]
+            .chunks_exact(8)
+            .map(|c| u64::from_le_bytes(c.try_into().unwrap()))
+            .collect();
 
         Ok(Self {
             mmap,
@@ -75,12 +73,10 @@ impl SparseG {
         })
     }
 
-    #[allow(dead_code)]
     pub fn n_samples(&self) -> u32 {
         self.n_samples
     }
 
-    #[allow(dead_code)]
     pub fn n_variants(&self) -> u32 {
         self.n_variants
     }

--- a/src/staar/stats.rs
+++ b/src/staar/stats.rs
@@ -2,10 +2,6 @@ use std::f64::consts::PI;
 
 use statrs::distribution::{ChiSquared, Continuous, ContinuousCDF, Normal};
 
-// ---------------------------------------------------------------------------
-// Cauchy combination test
-// ---------------------------------------------------------------------------
-
 /// Cauchy combination test (CCT) — equal weights.
 ///
 /// T = (1/K) * sum(tan((0.5 - p_i) * pi))
@@ -85,10 +81,6 @@ pub fn cauchy_combine_weighted(p_values: &[f64], weights: &[f64]) -> f64 {
 
     p.clamp(P_FLOOR, 1.0)
 }
-
-// ---------------------------------------------------------------------------
-// SKAT p-value via Liu et al. (2009) moment-matching
-// ---------------------------------------------------------------------------
 
 /// SKAT p-value via Liu et al. (2009) moment-matching.
 ///
@@ -190,10 +182,6 @@ pub fn mixture_chisq_pvalue(statistic: f64, eigenvalues: &[f64]) -> f64 {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Saddlepoint approximation (SPA) for binary trait score tests
-// ---------------------------------------------------------------------------
-
 /// Saddlepoint approximation for binary trait score tests.
 ///
 /// Provides calibrated p-values for imbalanced case-control designs where
@@ -218,7 +206,7 @@ pub fn spa_pvalue(score: f64, mu: &[f64], g: &[f64]) -> f64 {
         return 1.0;
     }
 
-    let norm = Normal::new(0.0, 1.0).unwrap();
+    let norm = Normal::new(0.0, 1.0).expect("standard normal params are valid");
 
     // Variance of the centered score S = G'(Y-μ) under H0: Var(S) = Σ μ_i(1-μ_i)g_i²
     let var: f64 = mu
@@ -285,15 +273,11 @@ fn tail_prob(q: f64, mu: &[f64], g: &[f64], norm: &Normal) -> f64 {
     (norm.cdf(-w) + norm.pdf(w) * (1.0 / w - 1.0 / v)).clamp(0.0, 1.0)
 }
 
-// ---------------------------------------------------------------------------
 // Cumulant generating function and derivatives for centered score S = G'(Y-μ)
-//
-// K(t)  = Σ [-t μ_i g_i + log(1 - μ_i + μ_i exp(t g_i))]
-// K'(t) = Σ [-μ_i g_i + μ_i g_i exp(t g_i) / (1 - μ_i + μ_i exp(t g_i))]
-// K''(t)= Σ μ_i(1-μ_i) g_i² exp(t g_i) / (1 - μ_i + μ_i exp(t g_i))²
-//
+//   K(t)  = Σ [-t μ_i g_i + log(1 - μ_i + μ_i exp(t g_i))]
+//   K'(t) = Σ [-μ_i g_i + μ_i g_i exp(t g_i) / (1 - μ_i + μ_i exp(t g_i))]
+//   K''(t)= Σ μ_i(1-μ_i) g_i² exp(t g_i) / (1 - μ_i + μ_i exp(t g_i))²
 // The -t·μ·g centering ensures K'(0) = 0, matching R's K_Binary_SPA.
-// ---------------------------------------------------------------------------
 
 fn cgf(t: f64, mu: &[f64], g: &[f64]) -> f64 {
     mu.iter()

--- a/src/staar/store.rs
+++ b/src/staar/store.rs
@@ -30,10 +30,6 @@ use crate::ingest::{ColumnContract, ColumnRequirement};
 use crate::output::Output;
 use crate::resource::Resources;
 
-// ---------------------------------------------------------------------------
-// Manifest & ChromInfo
-// ---------------------------------------------------------------------------
-
 #[derive(Serialize, Deserialize)]
 pub struct StoreManifest {
     pub version: u32,
@@ -50,10 +46,6 @@ pub struct ChromInfo {
     pub name: String,
     pub n_variants: usize,
 }
-
-// ---------------------------------------------------------------------------
-// Content fingerprinting
-// ---------------------------------------------------------------------------
 
 /// Content-based file fingerprint: SHA-256 of (first 1MB + last 1MB + file size).
 /// Survives path renames and HPC scratch migrations — only invalidates when
@@ -127,81 +119,34 @@ pub fn compute_key(vcf_path: &Path, annotations_path: &Path) -> Result<String, F
     Ok(format!("{:x}", hasher.finalize()))
 }
 
-// ---------------------------------------------------------------------------
-// Probe: check if a valid store exists
-// ---------------------------------------------------------------------------
-
 pub struct StoreProbe {
-    pub hit: bool,
     pub store_dir: PathBuf,
+    /// `Some` only when a valid, key-matching, fully-materialized store exists.
     pub manifest: Option<StoreManifest>,
 }
 
 pub fn probe(store_dir: &Path, vcf_path: &Path, annotations_path: &Path) -> StoreProbe {
     let store_dir = store_dir.to_path_buf();
-    let manifest_path = store_dir.join("manifest.json");
+    let miss = || StoreProbe { store_dir: store_dir.clone(), manifest: None };
 
-    let manifest = match fs::read_to_string(&manifest_path) {
-        Ok(s) => match serde_json::from_str::<StoreManifest>(&s) {
-            Ok(m) => m,
-            Err(_) => {
-                return StoreProbe {
-                    hit: false,
-                    store_dir,
-                    manifest: None,
-                }
-            }
-        },
-        Err(_) => {
-            return StoreProbe {
-                hit: false,
-                store_dir,
-                manifest: None,
-            }
-        }
-    };
-
-    let key = match compute_key(vcf_path, annotations_path) {
-        Ok(k) => k,
-        Err(_) => {
-            return StoreProbe {
-                hit: false,
-                store_dir,
-                manifest: None,
-            }
-        }
-    };
+    let Ok(s) = fs::read_to_string(store_dir.join("manifest.json")) else { return miss(); };
+    let Ok(manifest) = serde_json::from_str::<StoreManifest>(&s) else { return miss(); };
+    let Ok(key) = compute_key(vcf_path, annotations_path) else { return miss(); };
 
     if manifest.key != key || manifest.version != 3 {
-        return StoreProbe {
-            hit: false,
-            store_dir,
-            manifest: Some(manifest),
-        };
+        return miss();
     }
 
     for ci in &manifest.chromosomes {
         let sparse_g = store_dir.join(format!("chromosome={}/sparse_g.bin", ci.name));
         let variants = store_dir.join(format!("chromosome={}/variants.parquet", ci.name));
         if !sparse_g.exists() || !variants.exists() {
-            return StoreProbe {
-                hit: false,
-                store_dir,
-                manifest: Some(manifest),
-            };
+            return miss();
         }
     }
 
-    StoreProbe {
-        hit: true,
-        store_dir,
-        manifest: Some(manifest),
-    }
+    StoreProbe { store_dir, manifest: Some(manifest) }
 }
-
-// ---------------------------------------------------------------------------
-// Store builder orchestration
-// ---------------------------------------------------------------------------
 
 pub const STAAR_ANNOTATION_COLUMNS: &[ColumnRequirement] = &[
     ColumnRequirement {
@@ -276,19 +221,13 @@ pub fn build_or_load_store(
     res: &Resources,
     out: &dyn Output,
 ) -> Result<GenoStoreResult, FavorError> {
-    let probe_result = if !rebuild_store {
-        probe(store_dir, genotypes, annotations)
+    let probe_result = if rebuild_store {
+        StoreProbe { store_dir: store_dir.to_path_buf(), manifest: None }
     } else {
-        StoreProbe {
-            hit: false,
-            store_dir: store_dir.to_path_buf(),
-            manifest: None,
-        }
+        probe(store_dir, genotypes, annotations)
     };
 
-    if probe_result.hit {
-        // hit == true guarantees manifest is Some
-        let manifest = probe_result.manifest.unwrap();
+    if let Some(manifest) = probe_result.manifest {
         out.status(&format!(
             "Step 1/4: Using cached genotype store ({} variants x {} samples)",
             manifest.n_variants, manifest.n_samples,
@@ -417,10 +356,6 @@ pub fn run_annotation_join(
 
     Ok(engine)
 }
-
-// ---------------------------------------------------------------------------
-// Build store
-// ---------------------------------------------------------------------------
 
 pub fn build(
     engine: &DfEngine,

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,10 +8,6 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
-// ---------------------------------------------------------------------------
-// Chromosome
-// ---------------------------------------------------------------------------
-
 /// Strongly-typed chromosome identifier.
 ///
 /// `Ord` gives natural sort order: 1..22 < X < Y < MT.
@@ -108,10 +104,6 @@ impl<'de> Deserialize<'de> for Chromosome {
     }
 }
 
-// ---------------------------------------------------------------------------
-// AnnotationWeights
-// ---------------------------------------------------------------------------
-
 /// Fixed-size annotation weights for the 11 STAAR channels.
 ///
 /// Replaces `Vec<f64>` annotation_weights, `WEIGHT_COL_START` / `WEIGHT_COL_COUNT`
@@ -160,10 +152,6 @@ impl AnnotationWeights {
         "apc_transcription_factor",
     ];
 }
-
-// ---------------------------------------------------------------------------
-// RegionType
-// ---------------------------------------------------------------------------
 
 /// Strongly-typed GENCODE region type. Eliminates per-variant String allocations
 /// and replaces `.contains()` string matching in mask predicates with integer
@@ -271,10 +259,6 @@ impl RegionType {
         }
     }
 }
-
-// ---------------------------------------------------------------------------
-// Consequence
-// ---------------------------------------------------------------------------
 
 /// Strongly-typed variant consequence. Eliminates per-variant String allocations
 /// and turns mask predicates into integer match arms.
@@ -404,10 +388,6 @@ impl Consequence {
     }
 }
 
-// ---------------------------------------------------------------------------
-// RegulatoryFlags
-// ---------------------------------------------------------------------------
-
 /// Regulatory region flags used by mask predicates.
 ///
 /// Replaces 4 loose `bool` fields repeated in the old AnnotatedVariant and
@@ -419,10 +399,6 @@ pub struct RegulatoryFlags {
     pub ccre_promoter: bool,
     pub ccre_enhancer: bool,
 }
-
-// ---------------------------------------------------------------------------
-// FunctionalAnnotation
-// ---------------------------------------------------------------------------
 
 /// Everything STAAR needs to classify (masks) and weight (score tests) a variant.
 ///
@@ -437,10 +413,6 @@ pub struct FunctionalAnnotation {
     pub regulatory: RegulatoryFlags,
     pub weights: AnnotationWeights,
 }
-
-// ---------------------------------------------------------------------------
-// AnnotatedVariant (canonical)
-// ---------------------------------------------------------------------------
 
 /// Single canonical variant type used by masks, score tests, sumstats export,
 /// result writing, and MetaSTAAR merge.
@@ -457,19 +429,11 @@ pub struct AnnotatedVariant {
     pub annotation: FunctionalAnnotation,
 }
 
-// ---------------------------------------------------------------------------
-// Variant ID
-// ---------------------------------------------------------------------------
-
 /// Format a universal variant ID: "chr-pos-ref-alt" (e.g., "1-1001-A-T").
 /// Single source of truth — all vid construction calls this.
 pub fn format_vid(chrom: &str, position: u32, ref_allele: &str, alt_allele: &str) -> String {
     format!("{chrom}-{position}-{ref_allele}-{alt_allele}")
 }
-
-// ---------------------------------------------------------------------------
-// MetaVariant
-// ---------------------------------------------------------------------------
 
 /// A variant in a meta-analysis context. Composes `AnnotatedVariant` instead
 /// of duplicating its fields.
@@ -483,10 +447,6 @@ pub struct MetaVariant {
     pub n_total: i64,
     pub study_segments: Vec<(usize, i32)>,
 }
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
26 files, +133 −516. cargo test --release: 141/141.

Banner comments removed across the codebase. `StoreProbe::hit` field dropped (was redundant with `manifest: Option`, two paths could have desynced into Some+miss). `resource.rs` `detect_memory`/`threads`/`temp` flattened from nested if-let towers into `Option::or_else` chains. A handful of production `.unwrap()` panics replaced with `.expect(reason)` or restructured (`HashMap Entry`, `chunks_exact`). Unused `_chrom` param deleted from `meta_score_gene`.