### PR TITLE
kinship: drop stale #26 #27 references from doc comments

### DIFF
--- a/src/staar/kinship/UPSTREAM.md
+++ b/src/staar/kinship/UPSTREAM.md
@@ -89,22 +89,20 @@ So upstream's "sparse" path is really "sparse Cholesky factorization, dense
 inverse, exploit kinship sparsity in the Frobenius product". It costs `O(n^2)`
 memory.
 
-Our sparse path (`sparse.rs::ai_step_sparse`) does NOT materialize `Sigma_i`.
-It uses `factor.solve_in_place()` for `Sigma_i v` and a Hutchinson stochastic
-estimator for `tr(Sigma_i K_l)`. This costs `O(nnz_L * m)` memory where m is
-the probe count (default 30). It is an approximation with ~3% relative error
-on the trace term, which propagates into tau via the AI step.
+Our sparse path does NOT materialize `Sigma_i`. It uses
+`factor.solve_in_place()` for `Sigma_i v` and computes `tr(Sigma_i K_l)`
+exactly via the Takahashi (Erisman-Tinney) recursion, which walks the
+Cholesky factor of Σ to fill in the entries of `Sigma_i` at the union
+sparsity pattern of all kinship matrices. The Frobenius product
+`sum(Sigma_i * kins[[l]])` then reads those entries directly. This is
+mathematically 1:1 with upstream `R_fitglmm_ai` while still using
+strictly less memory than upstream (we never materialize the full
+`Sigma_i`, only the entries the Frobenius product needs).
 
-The Takahashi recursion in Phase 4 (#26 #27) replaces Hutchinson with an
-exact computation of `Sigma_i` entries restricted to the union sparsity pattern
-of all kinship matrices. Once that lands the sparse path is mathematically
-1:1 with upstream `R_fitglmm_ai` while still using strictly less memory than
-upstream (we never materialize the full `Sigma_i`, only the entries the
-Frobenius product needs).
-
-Until Phase 4 lands, the sparse path is "good approximation, ~3% trace
-error". After Phase 4 it is "1:1 with upstream, exact at the entry pattern".
-Document this clearly in PR A.
+A Hutchinson stochastic estimator (`hutchinson.rs`) is kept as a
+fallback under `SparseSolverKind::Hutchinson` and is exercised by the
+`sparse_fit_reml_pedigree_matches_dense_within_tolerance` test. It is
+not the default.
 
 ## PQL note
 

--- a/src/staar/kinship/mod.rs
+++ b/src/staar/kinship/mod.rs
@@ -65,8 +65,7 @@ use crate::error::FavorError;
 /// Fit AI-REML for the variance components in
 /// `[τ_kinship_1..τ_L, τ_group_1..τ_G]`. Dispatches between the dense
 /// kernel (small n, bit-identical to GMMAT) and the sparse kernel
-/// (large n + sparse kinships, matches GMMAT to within Hutchinson noise
-/// until #26 #27 lands).
+/// (large n + sparse kinships, exact via the Takahashi recursion).
 ///
 /// Returns `FavorError::Resource` if neither path can run within the
 /// configured memory budget.

--- a/src/staar/kinship/reml.rs
+++ b/src/staar/kinship/reml.rs
@@ -186,7 +186,7 @@ pub fn matvec_kinship(k: &KinshipMatrix, v: &Mat<f64>) -> Mat<f64> {
 ///   the Takahashi recursion. tr and diag are *exact* — 1:1 with
 ///   upstream `R/glmmkin.R::R_fitglmm_ai`'s `sum(Sigma_i * kins[[i]])`
 ///   formula, while using strictly less memory than upstream (we never
-///   materialize the dense inverse). Default sparse path. Closes #26 #27.
+///   materialize the dense inverse). Default sparse path.
 pub enum SigmaSolver {
     Dense(Mat<f64>),
     SparseHutchinson(SparseHutchinsonState),

--- a/src/staar/kinship/sparse/hutchinson.rs
+++ b/src/staar/kinship/sparse/hutchinson.rs
@@ -5,17 +5,11 @@
 //! fixed seed — same seed in, same float out, run-to-run.
 //!
 //! These are *approximations*. Standard error scales as `1/√M`; with
-//! `M = 30` the relative error is around 3%. They are kept as a fallback
-//! for when the Takahashi selected inversion in #26 #27 isn't available
-//! (very dense fill on the Cholesky factor, or when we want to keep the
-//! sparse path running on a backend that doesn't expose the simplicial
-//! Cholesky internals).
-//!
-//! Once Takahashi lands, the sparse trace and diagonal become exact at the
-//! union sparsity pattern of the kinship matrices, restoring 1:1
-//! correspondence with `R/glmmkin.R::R_fitglmm_ai:662-710`'s
-//! `sum(Sigma_i * kins[[i]])` Frobenius product. Until then, this module
-//! is the source of the trace term in the sparse AI step.
+//! `M = 30` the relative error is around 3%. The default sparse path uses
+//! the exact Takahashi recursion in [`super::takahashi`] instead. This
+//! module is kept as a fallback under `SparseSolverKind::Hutchinson` and
+//! is used by the regression test that confirms the stochastic path still
+//! produces valid-within-tolerance estimates against the dense path.
 
 use faer::sparse::linalg::solvers::Llt;
 use faer::sparse::SparseColMat;
@@ -75,8 +69,8 @@ pub fn sparse_matvec(k: &SparseColMat<u32, f64>, v: &Mat<f64>) -> Mat<f64> {
 /// is one sparse matvec plus one sparse Cholesky solve. With `M = 30`
 /// the relative error is ~3%.
 ///
-/// **Approximation, not exact.** Replaced by `takahashi::trace_k_exact`
-/// once #26 #27 lands.
+/// **Approximation, not exact.** The default sparse path uses
+/// [`super::takahashi`] instead.
 pub fn trace_k_estimate(
     factor: &Llt<u32, f64>,
     k_l: &SparseColMat<u32, f64>,
@@ -116,8 +110,8 @@ pub fn trace_k_estimate(
 /// diag(Σ⁻¹)[i] ≈ (1/M) Σ_m z_m[i] · solve(Σ, z_m)[i]
 /// ```
 ///
-/// Returns a length-`n` vector. Same seed → same output. Replaced by
-/// the Takahashi selected inverse once #26 #27 lands.
+/// Returns a length-`n` vector. Same seed → same output. The default
+/// sparse path uses the Takahashi selected inverse instead.
 pub fn diag_inverse_estimate(
     factor: &Llt<u32, f64>,
     n: usize,

--- a/src/staar/kinship/sparse/mod.rs
+++ b/src/staar/kinship/sparse/mod.rs
@@ -3,21 +3,19 @@
 //! When all loaded kinships are sparse and dense Σ⁻¹ would blow the memory
 //! budget, this module assembles the sparse Σ via [`assembler::Assembler`],
 //! factors it via faer's sparse Cholesky, and hands the factor to the shared
-//! [`crate::staar::kinship::reml`] loop wrapped in
-//! [`SigmaSolver::Sparse`](crate::staar::kinship::reml::SigmaSolver::Sparse).
+//! [`crate::staar::kinship::reml`] loop.
 //!
 //! upstream:
 //!   - per-iteration AI step → `R/glmmkin.R::R_fitglmm_ai:662-710` (the
-//!     sparse-aware variant). Upstream still materializes Σ⁻¹ as a dense
-//!     matrix because R's `chol2inv` does so even on sparse Cholesky output;
-//!     it then uses `sum(Sigma_i * kins[[i]])` to exploit kinship sparsity
-//!     in the Frobenius product. We do not materialize Σ⁻¹: the trace term
-//!     comes from a stochastic Hutchinson estimator until the Takahashi
-//!     selected inversion (#26 #27) lands and restores 1:1 correspondence.
+//!     sparse-aware variant). Upstream materializes Σ⁻¹ as a dense matrix
+//!     because R's `chol2inv` does so even on sparse Cholesky output, then
+//!     uses `sum(Sigma_i * kins[[i]])` to exploit kinship sparsity in the
+//!     Frobenius product. We do not materialize Σ⁻¹: the default
+//!     [`TakahashiBuilder`] runs the Erisman-Tinney recursion to fill in
+//!     the entries of Σ⁻¹ at the union sparsity pattern, which is exactly
+//!     what the Frobenius sum needs. [`HutchinsonBuilder`] is kept as a
+//!     stochastic fallback.
 //!   - convergence + boundary refit → shared in `reml.rs::run_reml`.
-//!
-//! See `UPSTREAM.md` "sparse path is not bit-identical to upstream" for
-//! the full story.
 
 pub mod assembler;
 pub mod hutchinson;
@@ -90,8 +88,7 @@ impl<'a> SolverBuilder for HutchinsonBuilder<'a> {
     }
 }
 
-/// Builder for the Takahashi-based sparse path. Default sparse builder
-/// (closes #26 #27).
+/// Builder for the Takahashi-based sparse path. Default sparse builder.
 ///
 /// Each AI iteration:
 ///   1. assemble fresh Σ values at current τ via the assembler

--- a/src/staar/kinship/sparse/takahashi.rs
+++ b/src/staar/kinship/sparse/takahashi.rs
@@ -14,8 +14,6 @@
 //! storing only the entries of `Sigma_inv` at the union sparsity pattern
 //! (orders of magnitude less memory for pedigree kinships).
 //!
-//! Closes #26, #27.
-//!
 //! ## The recursion
 //!
 //! Given the lower Cholesky factor `L` of `Σ` (so `Σ = L Lᵀ`), the entries


### PR DESCRIPTION
#36's body and a bunch of kinship doc comments referenced issues 26 and 27 as if they tracked the Takahashi work. Wrong numbers — those issues are about provenance and phenotype contracts. Reopened both, this rips the stale references out of the kinship docs.