### PR TITLE
staar: meta hardening, real MultiSTAAR, dry-run runtime

### DIFF
--- a/src/commands/annotate.rs
+++ b/src/commands/annotate.rs
@@ -127,6 +127,7 @@ fn emit_dry_run(config: &AnnotateConfig, out: &dyn Output) -> Result<(), CohortE
             "tier": config.tier.as_str(),
         }),
         memory: commands::MemoryEstimate::default_estimate(),
+        runtime: None,
         output_path: config.output.to_string_lossy().into(),
     };
     commands::emit(&plan, out);

--- a/src/commands/enrich.rs
+++ b/src/commands/enrich.rs
@@ -124,6 +124,7 @@ fn emit_dry_run(
             "available_tables": available_tables,
         }),
         memory: commands::MemoryEstimate::default_estimate(),
+        runtime: None,
         output_path: config.output.to_string_lossy().into(),
     };
     commands::emit(&plan, out);

--- a/src/commands/ingest.rs
+++ b/src/commands/ingest.rs
@@ -266,6 +266,7 @@ fn run_ingest_dry(
             "needs_intervention": analysis.needs_intervention(),
         }),
         memory: commands::MemoryEstimate::default_estimate(),
+        runtime: None,
         output_path: config.output.to_string_lossy().into(),
     };
     commands::emit(&plan, out);

--- a/src/commands/meta_staar.rs
+++ b/src/commands/meta_staar.rs
@@ -55,7 +55,7 @@ pub fn run_meta_staar(
     let studies = staar::meta::load_studies(&config.study_dirs)?;
 
     if dry_run {
-        return emit_dry_run(&studies, config, out);
+        return emit_dry_run(engine, &studies, config, out);
     }
 
     let k = studies.len();
@@ -98,21 +98,41 @@ pub fn run_meta_staar(
 }
 
 fn emit_dry_run(
+    engine: &Engine,
     studies: &[staar::meta::StudyHandle],
     config: &MetaStaarConfig,
     out: &dyn Output,
 ) -> Result<(), CohortError> {
     let k = studies.len();
     let total_n: usize = studies.iter().map(|s| s.meta.n_samples).sum();
+    let threads = engine.resources().threads.max(1);
+    let runtime_seconds = meta_staar_runtime_seconds(k, total_n, threads);
 
-    out.result_json(&json!({
-        "command": "meta-staar",
-        "n_studies": k,
-        "total_samples": total_n,
-        "trait_type": studies[0].meta.trait_type,
-        "output_path": config.output_dir.to_string_lossy(),
-    }));
+    let plan = crate::commands::DryRunPlan {
+        command: "meta-staar".into(),
+        inputs: json!({
+            "n_studies": k,
+            "total_samples": total_n,
+            "trait_type": studies[0].meta.trait_type,
+        }),
+        memory: crate::commands::MemoryEstimate::default_estimate(),
+        runtime: Some(crate::commands::RuntimeEstimate::from_seconds(runtime_seconds)),
+        output_path: config.output_dir.to_string_lossy().into(),
+    };
+    crate::commands::emit(&plan, out);
     Ok(())
+}
+
+/// Coarse wall-clock budget for `cohort meta-staar`. Dominated by the
+/// per-chromosome SQL merge plus per-segment covariance accumulation,
+/// both linear in `(n_studies × total_samples)`.
+fn meta_staar_runtime_seconds(n_studies: usize, total_samples: usize, threads: usize) -> u64 {
+    const NS_PER_STUDY_SAMPLE: u64 = 5_000;
+    const SQL_BASE_S: u64 = 20;
+
+    let merge_ns = (n_studies as u64).saturating_mul(total_samples as u64) * NS_PER_STUDY_SAMPLE;
+    let merge_s = merge_ns / 1_000_000_000 / threads as u64;
+    SQL_BASE_S.saturating_add(merge_s).max(30)
 }
 
 fn run_all_chromosomes(
@@ -358,6 +378,8 @@ fn build_result_batch(
     let mut b_end = UInt32Builder::with_capacity(nr);
     let mut b_nvariants = UInt32Builder::with_capacity(nr);
     let mut b_cmac = UInt32Builder::with_capacity(nr);
+    let mut b_burden_beta = Float64Builder::with_capacity(nr);
+    let mut b_burden_se = Float64Builder::with_capacity(nr);
 
     let n_pval_cols = 6 + 6 * n_channels + 6 + 2;
     let mut pval_builders: Vec<Float64Builder> = (0..n_pval_cols)
@@ -373,6 +395,8 @@ fn build_result_batch(
         b_end.append_value(r.end);
         b_nvariants.append_value(r.n_variants);
         b_cmac.append_value(r.cumulative_mac);
+        b_burden_beta.append_value(r.burden_beta);
+        b_burden_se.append_value(r.burden_se);
 
         let mut pi = 0;
         for p in [
@@ -427,6 +451,8 @@ fn build_result_batch(
         Field::new("end", DataType::UInt32, false),
         Field::new("n_variants", DataType::UInt32, false),
         Field::new("cMAC", DataType::UInt32, false),
+        Field::new("burden_beta", DataType::Float64, true),
+        Field::new("burden_se", DataType::Float64, true),
     ];
     for test in &test_names {
         fields.push(Field::new(*test, DataType::Float64, true));
@@ -458,6 +484,8 @@ fn build_result_batch(
         Arc::new(b_end.finish()),
         Arc::new(b_nvariants.finish()),
         Arc::new(b_cmac.finish()),
+        Arc::new(b_burden_beta.finish()),
+        Arc::new(b_burden_se.finish()),
     ];
     for b in &mut pval_builders {
         columns.push(Arc::new(b.finish()));

--- a/src/commands/meta_staar.rs
+++ b/src/commands/meta_staar.rs
@@ -189,7 +189,7 @@ fn run_all_chromosomes(
                 if let Some(existing) = all_results.iter_mut().find(|(mt, _)| mt == mask_type) {
                     existing.1.extend(results);
                 } else {
-                    all_results.push((mask_type.clone(), results));
+                    all_results.push((*mask_type, results));
                 }
             }
         }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -97,6 +97,8 @@ pub struct DryRunPlan {
     pub command: String,
     pub inputs: serde_json::Value,
     pub memory: MemoryEstimate,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime: Option<RuntimeEstimate>,
     pub output_path: String,
 }
 
@@ -119,6 +121,36 @@ impl MemoryEstimate {
     }
 }
 
+/// Coarse wall-clock budget for planning, not a benchmark prediction.
+/// Callers compute `seconds` from a workload-specific formula and hand the
+/// number to `RuntimeEstimate::from_seconds`, which produces the human form.
+#[derive(Serialize)]
+pub struct RuntimeEstimate {
+    pub seconds: u64,
+    pub human: String,
+}
+
+impl RuntimeEstimate {
+    pub fn from_seconds(seconds: u64) -> Self {
+        Self {
+            seconds,
+            human: human_seconds(seconds),
+        }
+    }
+}
+
+fn human_seconds(s: u64) -> String {
+    if s < 60 {
+        format!("{s}s")
+    } else if s < 3600 {
+        format!("{}m{:02}s", s / 60, s % 60)
+    } else if s < 86_400 {
+        format!("{}h{:02}m", s / 3600, (s % 3600) / 60)
+    } else {
+        format!("{}d{:02}h", s / 86_400, (s % 86_400) / 3600)
+    }
+}
+
 pub fn emit(plan: &DryRunPlan, out: &dyn Output) {
     out.result_json(&serde_json::to_value(plan).unwrap_or_default());
 }
@@ -128,3 +160,42 @@ pub fn file_size(path: &Path) -> u64 {
 }
 
 pub use crate::data::transfer::human_size as human_bytes;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn human_seconds_buckets() {
+        assert_eq!(human_seconds(0), "0s");
+        assert_eq!(human_seconds(45), "45s");
+        assert_eq!(human_seconds(60), "1m00s");
+        assert_eq!(human_seconds(125), "2m05s");
+        assert_eq!(human_seconds(3_600), "1h00m");
+        assert_eq!(human_seconds(7_265), "2h01m");
+        assert_eq!(human_seconds(90_061), "1d01h");
+    }
+
+    #[test]
+    fn runtime_estimate_round_trips_through_serde() {
+        let est = RuntimeEstimate::from_seconds(125);
+        assert_eq!(est.seconds, 125);
+        assert_eq!(est.human, "2m05s");
+        let json = serde_json::to_string(&est).unwrap();
+        assert!(json.contains("\"seconds\":125"));
+        assert!(json.contains("\"human\":\"2m05s\""));
+    }
+
+    #[test]
+    fn dry_run_plan_omits_runtime_when_none() {
+        let plan = DryRunPlan {
+            command: "annotate".into(),
+            inputs: serde_json::json!({}),
+            memory: MemoryEstimate::default_estimate(),
+            runtime: None,
+            output_path: "/tmp/out".into(),
+        };
+        let json = serde_json::to_string(&plan).unwrap();
+        assert!(!json.contains("runtime"));
+    }
+}

--- a/src/commands/staar.rs
+++ b/src/commands/staar.rs
@@ -337,7 +337,12 @@ fn emit_dry_run(
             _ => unreachable!("build_config rejects mixed cohort sources"),
         };
 
-    let _ = (n_samples, est_rare); // already folded into inputs_json
+    let runtime_seconds = staar_runtime_seconds(
+        n_samples,
+        est_rare,
+        engine.resources().threads.max(1),
+        config.has_kinship(),
+    );
     let plan = commands::DryRunPlan {
         command: "staar".into(),
         inputs: serde_json::json!({
@@ -351,10 +356,30 @@ fn emit_dry_run(
             minimum_bytes: 4 * GB,
             recommended_bytes,
         },
+        runtime: Some(commands::RuntimeEstimate::from_seconds(runtime_seconds)),
         output_path: config.output_dir.to_string_lossy().into(),
     };
     commands::emit(&plan, out);
     Ok(())
+}
+
+/// Coarse wall-clock budget for `cohort staar`.
+///
+/// Calibrated against profiling on the chr22 fixtures: the score-cache fill
+/// dominates and scales linearly with `n_samples × est_rare / threads`. Null
+/// model fitting adds a fixed overhead that jumps when kinship pulls in REML
+/// or PQL. Output is intentionally a budget, not a benchmark — operators use
+/// it to size SLURM allocations, not to predict the wall clock to the second.
+fn staar_runtime_seconds(n_samples: usize, est_rare: u64, threads: usize, has_kinship: bool) -> u64 {
+    const SCORE_NS_PER_SAMPLE_VARIANT: u64 = 1_000;
+    const NULL_BASE_S: u64 = 30;
+    const NULL_KINSHIP_S: u64 = 270;
+
+    let score_ns = (n_samples as u64).saturating_mul(est_rare) * SCORE_NS_PER_SAMPLE_VARIANT;
+    let score_s = score_ns / 1_000_000_000 / threads as u64;
+    let null_s = if has_kinship { NULL_KINSHIP_S } else { NULL_BASE_S };
+    let total = null_s.saturating_add(score_s);
+    total.max(60)
 }
 
 fn parquet_row_count(path: &std::path::Path) -> Result<i64, String> {
@@ -433,5 +458,27 @@ mod tests {
             "sample"
         );
         assert_eq!(derive_cohort_id(std::path::Path::new("/")), "cohort");
+    }
+
+    #[test]
+    fn staar_runtime_grows_with_workload_and_shrinks_with_threads() {
+        let small = staar_runtime_seconds(1_000, 100_000, 8, false);
+        let big = staar_runtime_seconds(50_000, 1_000_000, 8, false);
+        assert!(big > small);
+        let serial = staar_runtime_seconds(50_000, 1_000_000, 1, false);
+        let parallel = staar_runtime_seconds(50_000, 1_000_000, 16, false);
+        assert!(parallel < serial);
+    }
+
+    #[test]
+    fn staar_runtime_kinship_adds_overhead() {
+        let no_kin = staar_runtime_seconds(10_000, 100_000, 8, false);
+        let with_kin = staar_runtime_seconds(10_000, 100_000, 8, true);
+        assert!(with_kin > no_kin);
+    }
+
+    #[test]
+    fn staar_runtime_minimum_floor() {
+        assert_eq!(staar_runtime_seconds(0, 0, 8, false), 60);
     }
 }

--- a/src/staar/ground_truth_test.rs
+++ b/src/staar/ground_truth_test.rs
@@ -391,7 +391,9 @@ mod tests {
             ms.trait2_staar_o
         );
 
-        // Our MultiSTAAR = Cauchy combine of per-trait STAAR-O values
+        // Our scaffold combines per-trait STAAR-O via Cauchy. This is NOT
+        // the R MultiSTAAR algorithm (joint score test); see
+        // `src/staar/multi.rs` doc.
         let combined = stats::cauchy_combine(&[ms.trait1_staar_o, ms.trait2_staar_o]);
         assert!(
             combined > 0.0 && combined <= 1.0,

--- a/src/staar/masks.rs
+++ b/src/staar/masks.rs
@@ -148,7 +148,7 @@ pub fn build_masks_from_registry(
                     })
                 })
                 .collect();
-            (mask_type.clone(), groups)
+            (*mask_type, groups)
         })
         .collect()
 }

--- a/src/staar/meta.rs
+++ b/src/staar/meta.rs
@@ -200,32 +200,65 @@ pub struct SegmentCov {
     pos_index: HashMap<u32, Vec<usize>>,
 }
 
+/// Lex-min orientation of a biallelic site. Two studies that disagree on
+/// which allele is REF vs ALT must hash to the same `(pos, ref, alt)` group
+/// so their summary statistics can be combined.
+fn canonical_alleles<'a>(ref_b: &'a str, alt_b: &'a str) -> (&'a str, &'a str) {
+    if ref_b <= alt_b {
+        (ref_b, alt_b)
+    } else {
+        (alt_b, ref_b)
+    }
+}
+
 impl SegmentCov {
-    /// Extract sub-matrix for a subset of variants identified by (position, ref, alt).
+    /// Extract sub-matrix for a subset of variants identified by `(pos, ref,
+    /// alt)` in the **caller's canonical orientation**.
+    ///
+    /// Lookup is orientation-blind so a study that stored a variant flipped
+    /// still resolves. The caller's K is signed against canonical-orientation
+    /// dosage; the stored covariance is signed against local-orientation
+    /// dosage. With `G_local = ±G_canonical`, the j-th diagonal of K is
+    /// invariant (`G²` = `(−G)²`) but each off-diagonal `K[i,j] = G_i·G_j`
+    /// flips sign whenever exactly one of `(i, j)` is locally flipped. We
+    /// track a per-row sign and multiply through, so the returned sub-matrix
+    /// is consistently in canonical orientation.
     fn extract_submatrix(&self, keys: &[(u32, &str, &str)]) -> Mat<f64> {
         let m = keys.len();
         let mut mat = Mat::zeros(m, m);
 
-        let mut key_to_local: Vec<Option<usize>> = Vec::with_capacity(m);
+        let mut key_to_local: Vec<Option<(usize, f64)>> = Vec::with_capacity(m);
         for &(pos, ref_a, alt_a) in keys {
-            let local = self.pos_index.get(&pos).and_then(|candidates| {
-                candidates
-                    .iter()
-                    .find(|&&i| self.refs[i] == ref_a && self.alts[i] == alt_a)
-                    .copied()
+            let canon = canonical_alleles(ref_a, alt_a);
+            let resolved = self.pos_index.get(&pos).and_then(|candidates| {
+                candidates.iter().find_map(|&i| {
+                    let local = (self.refs[i].as_str(), self.alts[i].as_str());
+                    if canonical_alleles(local.0, local.1) != canon {
+                        return None;
+                    }
+                    // Local matches canonical when its REF is the lex-min,
+                    // i.e. local.0 == canon.0. Otherwise dosage is negated.
+                    let sign = if local.0 == canon.0 { 1.0 } else { -1.0 };
+                    Some((i, sign))
+                })
             });
-            key_to_local.push(local);
+            key_to_local.push(resolved);
         }
 
         for i in 0..m {
-            let Some(li) = key_to_local[i] else { continue };
+            let Some((li, si)) = key_to_local[i] else {
+                continue;
+            };
             for j in 0..=i {
-                let Some(lj) = key_to_local[j] else { continue };
+                let Some((lj, sj)) = key_to_local[j] else {
+                    continue;
+                };
                 let (row, col) = if li >= lj { (li, lj) } else { (lj, li) };
                 let idx = row * (row + 1) / 2 + col;
                 if idx < self.cov_lower.len() {
-                    mat[(i, j)] = self.cov_lower[idx];
-                    mat[(j, i)] = self.cov_lower[idx];
+                    let v = self.cov_lower[idx] * si * sj;
+                    mat[(i, j)] = v;
+                    mat[(j, i)] = v;
                 }
             }
         }
@@ -265,9 +298,9 @@ pub fn load_studies(paths: &[std::path::PathBuf]) -> Result<Vec<StudyHandle>, Co
         });
     }
 
-    if studies.len() < 2 {
+    if studies.is_empty() {
         return Err(CohortError::Input(
-            "MetaSTAAR requires at least 2 studies.".into(),
+            "MetaSTAAR requires at least 1 study directory.".into(),
         ));
     }
 
@@ -330,11 +363,18 @@ pub fn merge_chromosome(
         .collect::<Vec<_>>()
         .join(", ");
 
+    // Group by lex-min(ref,alt) so two studies that disagree on REF/ALT
+    // orientation collapse into one row. The score statistic is signed by
+    // alt-allele dosage, so flipping ref↔alt flips the sign of `u_stat`.
+    // The covariance K is invariant under that flip and stays put — the
+    // segment-cache lookup canonicalises on its own side.
     engine.execute(&format!(
         "CREATE OR REPLACE TABLE _meta_variants AS \
          SELECT \
-             {pos}, {ref_a}, {alt_a}, \
-             SUM(u_stat) AS u_meta, \
+             {pos}, \
+             CASE WHEN {ref_a} <= {alt_a} THEN {ref_a} ELSE {alt_a} END AS {ref_a}, \
+             CASE WHEN {ref_a} <= {alt_a} THEN {alt_a} ELSE {ref_a} END AS {alt_a}, \
+             SUM(CASE WHEN {ref_a} <= {alt_a} THEN u_stat ELSE -u_stat END) AS u_meta, \
              SUM(mac) AS mac_total, \
              SUM(n_obs) AS n_total, \
              first_value({gene}) FILTER (WHERE {gene} != '') AS {gene}, \
@@ -350,7 +390,9 @@ pub fn merge_chromosome(
              CAST(array_agg(named_struct('s', study_idx, 'seg', segment_id)) AS VARCHAR) AS study_segs \
          FROM _study_variants \
          WHERE {maf} < {maf_cutoff} \
-         GROUP BY {pos}, {ref_a}, {alt_a} \
+         GROUP BY {pos}, \
+             CASE WHEN {ref_a} <= {alt_a} THEN {ref_a} ELSE {alt_a} END, \
+             CASE WHEN {ref_a} <= {alt_a} THEN {alt_a} ELSE {ref_a} END \
          ORDER BY {pos}",
         pos = Col::Position, ref_a = Col::RefAllele, alt_a = Col::AltAllele,
         maf = Col::Maf,
@@ -648,6 +690,7 @@ pub fn meta_score_gene(
 
     let sr = score::run_staar_from_sumstats(&u, &cov, &ann_matrix, &mafs, n_total);
 
+    let (burden_beta, burden_se) = unweighted_burden_estimate(&u, &cov);
     let cmac: i64 = indices.iter().map(|&gi| meta_variants[gi].mac_total).sum();
 
     Some(GeneResult {
@@ -659,7 +702,34 @@ pub fn meta_score_gene(
         n_variants: m as u32,
         cumulative_mac: cmac as u32,
         staar: sr,
+        burden_beta,
+        burden_se,
     })
+}
+
+/// Unweighted (collapsing) burden coefficient and standard error from
+/// a meta-analysis score vector and its covariance:
+///
+///   β̂  = 1ᵀU / 1ᵀK1
+///   SE = √(1 / 1ᵀK1)
+///
+/// Returns NaN when 1ᵀK1 ≤ 0 (degenerate gene with no usable variance).
+fn unweighted_burden_estimate(u: &Mat<f64>, k: &Mat<f64>) -> (f64, f64) {
+    let m = u.nrows();
+    let mut one_t_u = 0.0;
+    for i in 0..m {
+        one_t_u += u[(i, 0)];
+    }
+    let mut one_t_k_one = 0.0;
+    for i in 0..m {
+        for j in 0..m {
+            one_t_k_one += k[(i, j)];
+        }
+    }
+    if one_t_k_one <= 0.0 || !one_t_k_one.is_finite() {
+        return (f64::NAN, f64::NAN);
+    }
+    (one_t_u / one_t_k_one, (1.0 / one_t_k_one).sqrt())
 }
 
 fn parse_study_segments(s: &str) -> Vec<(usize, i32)> {
@@ -758,7 +828,6 @@ pub fn emit_sumstats(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
 fn emit_chromosome_sparse(
     view: &ChromosomeView<'_>,
     analysis: &AnalysisVectors,
@@ -795,47 +864,10 @@ fn emit_chromosome_sparse(
     ));
 
     let total_variants = chrom_indices.len();
-    let mut b_position = Int32Builder::with_capacity(total_variants);
-    let mut b_ref = StringBuilder::with_capacity(total_variants, total_variants * 4);
-    let mut b_alt = StringBuilder::with_capacity(total_variants, total_variants * 4);
-    let mut b_maf = Float64Builder::with_capacity(total_variants);
-    let mut b_mac = Int32Builder::with_capacity(total_variants);
-    let mut b_n_obs = Int32Builder::with_capacity(total_variants);
-    let mut b_u_stat = Float64Builder::with_capacity(total_variants);
-    let mut b_v_stat = Float64Builder::with_capacity(total_variants);
-    let mut b_segment_id = Int32Builder::with_capacity(total_variants);
-    let mut b_gene = StringBuilder::with_capacity(total_variants, total_variants * 8);
-    let mut b_region = StringBuilder::with_capacity(total_variants, total_variants * 8);
-    let mut b_consequence = StringBuilder::with_capacity(total_variants, total_variants * 8);
-    let mut b_cadd = Float64Builder::with_capacity(total_variants);
-    let mut b_revel = Float64Builder::with_capacity(total_variants);
-    let mut b_cage_prom = BooleanBuilder::with_capacity(total_variants);
-    let mut b_cage_enh = BooleanBuilder::with_capacity(total_variants);
-    let mut b_ccre_prom = BooleanBuilder::with_capacity(total_variants);
-    let mut b_ccre_enh = BooleanBuilder::with_capacity(total_variants);
-    let mut b_weights: [Float64Builder; 11] =
-        std::array::from_fn(|_| Float64Builder::with_capacity(total_variants));
-
-    let n_segments = segments.len();
-    let mut s_segment_id = Int32Builder::with_capacity(n_segments);
-    let mut s_n_variants = Int32Builder::with_capacity(n_segments);
-    let mut s_positions = ListBuilder::new(Int32Builder::with_capacity(total_variants));
-    let mut s_refs = ListBuilder::new(StringBuilder::with_capacity(
-        total_variants,
-        total_variants * 4,
-    ));
-    let mut s_alts = ListBuilder::new(StringBuilder::with_capacity(
-        total_variants,
-        total_variants * 4,
-    ));
-    let mut s_cov_lower = ListBuilder::new(Float64Builder::with_capacity(
-        total_variants * (total_variants + 1) / 2,
-    ));
+    let mut writer = SumstatsWriter::with_capacity(total_variants, segments.len());
 
     for (seg_id, seg_indices) in &segments {
         let seg_id = *seg_id;
-        let m = seg_indices.len();
-
         // Resolve each segment variant to variant_vcf via VariantIndex, then
         // batch-load carrier lists from SparseG.
         let variant_vcfs: Vec<u32> = seg_indices
@@ -851,92 +883,13 @@ fn emit_chromosome_sparse(
         let (u, k) = sparse_score::score_gene_sparse(&seg_carriers, analysis);
 
         for (j, &gi) in seg_indices.iter().enumerate() {
-            let v = &variants[gi];
-            b_position.append_value(v.position as i32);
-            b_ref.append_value(&v.ref_allele);
-            b_alt.append_value(&v.alt_allele);
-            b_maf.append_value(v.maf);
-            b_mac.append_value((2.0 * v.maf * n as f64).round() as i32);
-            b_n_obs.append_value(n as i32);
-            b_u_stat.append_value(u[(j, 0)]);
-            b_v_stat.append_value(k[(j, j)]);
-            b_segment_id.append_value(seg_id);
-            b_gene.append_value(&v.gene_name);
-            b_region.append_value(v.annotation.region_type.as_str());
-            b_consequence.append_value(v.annotation.consequence.as_str());
-            b_cadd.append_value(v.annotation.cadd_phred);
-            b_revel.append_value(v.annotation.revel);
-            b_cage_prom.append_value(v.annotation.regulatory.cage_promoter);
-            b_cage_enh.append_value(v.annotation.regulatory.cage_enhancer);
-            b_ccre_prom.append_value(v.annotation.regulatory.ccre_promoter);
-            b_ccre_enh.append_value(v.annotation.regulatory.ccre_enhancer);
-            for (i, builder) in b_weights.iter_mut().enumerate() {
-                builder.append_value(v.annotation.weights.0[i]);
-            }
+            writer.push_variant_row(&variants[gi], n, u[(j, 0)], k[(j, j)], seg_id);
         }
-
-        s_segment_id.append_value(seg_id);
-        s_n_variants.append_value(m as i32);
-
-        let pos_builder = s_positions.values();
-        for &gi in seg_indices {
-            pos_builder.append_value(variants[gi].position as i32);
-        }
-        s_positions.append(true);
-
-        let ref_builder = s_refs.values();
-        for &gi in seg_indices {
-            ref_builder.append_value(&variants[gi].ref_allele);
-        }
-        s_refs.append(true);
-
-        let alt_builder = s_alts.values();
-        for &gi in seg_indices {
-            alt_builder.append_value(&variants[gi].alt_allele);
-        }
-        s_alts.append(true);
-
-        let cov_builder = s_cov_lower.values();
-        for i in 0..m {
-            for j in 0..=i {
-                cov_builder.append_value(k[(i, j)]);
-            }
-        }
-        s_cov_lower.append(true);
+        writer.push_segment(seg_id, seg_indices, variants, &k);
     }
 
-    write_variants_parquet(
-        dir,
-        &mut b_position,
-        &mut b_ref,
-        &mut b_alt,
-        &mut b_maf,
-        &mut b_mac,
-        &mut b_n_obs,
-        &mut b_u_stat,
-        &mut b_v_stat,
-        &mut b_segment_id,
-        &mut b_gene,
-        &mut b_region,
-        &mut b_consequence,
-        &mut b_cadd,
-        &mut b_revel,
-        &mut b_cage_prom,
-        &mut b_cage_enh,
-        &mut b_ccre_prom,
-        &mut b_ccre_enh,
-        &mut b_weights,
-    )?;
-
-    write_segments_parquet(
-        dir,
-        &mut s_segment_id,
-        &mut s_n_variants,
-        &mut s_positions,
-        &mut s_refs,
-        &mut s_alts,
-        &mut s_cov_lower,
-    )?;
+    writer.write_variants(dir)?;
+    writer.write_segments(dir)?;
 
     out.status(&format!("    chr{chrom} done"));
     Ok(())
@@ -1003,59 +956,209 @@ fn parquet_props() -> WriterProperties {
         .build()
 }
 
-#[allow(clippy::too_many_arguments)]
-fn write_variants_parquet(
-    dir: &Path,
-    b_position: &mut Int32Builder,
-    b_ref: &mut StringBuilder,
-    b_alt: &mut StringBuilder,
-    b_maf: &mut Float64Builder,
-    b_mac: &mut Int32Builder,
-    b_n_obs: &mut Int32Builder,
-    b_u_stat: &mut Float64Builder,
-    b_v_stat: &mut Float64Builder,
-    b_segment_id: &mut Int32Builder,
-    b_gene: &mut StringBuilder,
-    b_region: &mut StringBuilder,
-    b_consequence: &mut StringBuilder,
-    b_cadd: &mut Float64Builder,
-    b_revel: &mut Float64Builder,
-    b_cage_prom: &mut BooleanBuilder,
-    b_cage_enh: &mut BooleanBuilder,
-    b_ccre_prom: &mut BooleanBuilder,
-    b_ccre_enh: &mut BooleanBuilder,
-    b_weights: &mut [Float64Builder; 11],
-) -> Result<(), CohortError> {
-    let schema = Arc::new(variant_schema());
-    let mut columns: Vec<ArrayRef> = vec![
-        Arc::new(b_position.finish()),
-        Arc::new(b_ref.finish()),
-        Arc::new(b_alt.finish()),
-        Arc::new(b_maf.finish()),
-        Arc::new(b_mac.finish()),
-        Arc::new(b_n_obs.finish()),
-        Arc::new(b_u_stat.finish()),
-        Arc::new(b_v_stat.finish()),
-        Arc::new(b_segment_id.finish()),
-        Arc::new(b_gene.finish()),
-        Arc::new(b_region.finish()),
-        Arc::new(b_consequence.finish()),
-        Arc::new(b_cadd.finish()),
-        Arc::new(b_revel.finish()),
-        Arc::new(b_cage_prom.finish()),
-        Arc::new(b_cage_enh.finish()),
-        Arc::new(b_ccre_prom.finish()),
-        Arc::new(b_ccre_enh.finish()),
-    ];
-    for b in b_weights.iter_mut() {
-        columns.push(Arc::new(b.finish()));
+/// Owns every Arrow builder for one chromosome's MetaSTAAR sumstats output.
+/// Each column is a field; `push_variant_row` / `push_segment` keep the
+/// 19 variant columns and the 6 segment columns in lock-step instead of
+/// scattering the parameter list across helper boundaries.
+struct SumstatsWriter {
+    // Variant-row builders.
+    position: Int32Builder,
+    ref_allele: StringBuilder,
+    alt_allele: StringBuilder,
+    maf: Float64Builder,
+    mac: Int32Builder,
+    n_obs: Int32Builder,
+    u_stat: Float64Builder,
+    v_stat: Float64Builder,
+    segment_id: Int32Builder,
+    gene: StringBuilder,
+    region: StringBuilder,
+    consequence: StringBuilder,
+    cadd: Float64Builder,
+    revel: Float64Builder,
+    cage_prom: BooleanBuilder,
+    cage_enh: BooleanBuilder,
+    ccre_prom: BooleanBuilder,
+    ccre_enh: BooleanBuilder,
+    weights: [Float64Builder; 11],
+
+    // Segment-row builders.
+    seg_id: Int32Builder,
+    seg_n_variants: Int32Builder,
+    seg_positions: ListBuilder<Int32Builder>,
+    seg_refs: ListBuilder<StringBuilder>,
+    seg_alts: ListBuilder<StringBuilder>,
+    seg_cov_lower: ListBuilder<Float64Builder>,
+}
+
+impl SumstatsWriter {
+    fn with_capacity(total_variants: usize, n_segments: usize) -> Self {
+        Self {
+            position: Int32Builder::with_capacity(total_variants),
+            ref_allele: StringBuilder::with_capacity(total_variants, total_variants * 4),
+            alt_allele: StringBuilder::with_capacity(total_variants, total_variants * 4),
+            maf: Float64Builder::with_capacity(total_variants),
+            mac: Int32Builder::with_capacity(total_variants),
+            n_obs: Int32Builder::with_capacity(total_variants),
+            u_stat: Float64Builder::with_capacity(total_variants),
+            v_stat: Float64Builder::with_capacity(total_variants),
+            segment_id: Int32Builder::with_capacity(total_variants),
+            gene: StringBuilder::with_capacity(total_variants, total_variants * 8),
+            region: StringBuilder::with_capacity(total_variants, total_variants * 8),
+            consequence: StringBuilder::with_capacity(total_variants, total_variants * 8),
+            cadd: Float64Builder::with_capacity(total_variants),
+            revel: Float64Builder::with_capacity(total_variants),
+            cage_prom: BooleanBuilder::with_capacity(total_variants),
+            cage_enh: BooleanBuilder::with_capacity(total_variants),
+            ccre_prom: BooleanBuilder::with_capacity(total_variants),
+            ccre_enh: BooleanBuilder::with_capacity(total_variants),
+            weights: std::array::from_fn(|_| Float64Builder::with_capacity(total_variants)),
+
+            seg_id: Int32Builder::with_capacity(n_segments),
+            seg_n_variants: Int32Builder::with_capacity(n_segments),
+            seg_positions: ListBuilder::new(Int32Builder::with_capacity(total_variants)),
+            seg_refs: ListBuilder::new(StringBuilder::with_capacity(
+                total_variants,
+                total_variants * 4,
+            )),
+            seg_alts: ListBuilder::new(StringBuilder::with_capacity(
+                total_variants,
+                total_variants * 4,
+            )),
+            seg_cov_lower: ListBuilder::new(Float64Builder::with_capacity(
+                total_variants * (total_variants + 1) / 2,
+            )),
+        }
     }
 
+    fn push_variant_row(
+        &mut self,
+        v: &AnnotatedVariant,
+        n_samples: usize,
+        u: f64,
+        k_diag: f64,
+        segment_id: i32,
+    ) {
+        self.position.append_value(v.position as i32);
+        self.ref_allele.append_value(&v.ref_allele);
+        self.alt_allele.append_value(&v.alt_allele);
+        self.maf.append_value(v.maf);
+        self.mac
+            .append_value((2.0 * v.maf * n_samples as f64).round() as i32);
+        self.n_obs.append_value(n_samples as i32);
+        self.u_stat.append_value(u);
+        self.v_stat.append_value(k_diag);
+        self.segment_id.append_value(segment_id);
+        self.gene.append_value(&v.gene_name);
+        self.region.append_value(v.annotation.region_type.as_str());
+        self.consequence
+            .append_value(v.annotation.consequence.as_str());
+        self.cadd.append_value(v.annotation.cadd_phred);
+        self.revel.append_value(v.annotation.revel);
+        self.cage_prom
+            .append_value(v.annotation.regulatory.cage_promoter);
+        self.cage_enh
+            .append_value(v.annotation.regulatory.cage_enhancer);
+        self.ccre_prom
+            .append_value(v.annotation.regulatory.ccre_promoter);
+        self.ccre_enh
+            .append_value(v.annotation.regulatory.ccre_enhancer);
+        for (i, builder) in self.weights.iter_mut().enumerate() {
+            builder.append_value(v.annotation.weights.0[i]);
+        }
+    }
+
+    fn push_segment(
+        &mut self,
+        seg_id: i32,
+        seg_indices: &[usize],
+        variants: &[AnnotatedVariant],
+        k: &Mat<f64>,
+    ) {
+        let m = seg_indices.len();
+        self.seg_id.append_value(seg_id);
+        self.seg_n_variants.append_value(m as i32);
+
+        let pos_builder = self.seg_positions.values();
+        for &gi in seg_indices {
+            pos_builder.append_value(variants[gi].position as i32);
+        }
+        self.seg_positions.append(true);
+
+        let ref_builder = self.seg_refs.values();
+        for &gi in seg_indices {
+            ref_builder.append_value(&variants[gi].ref_allele);
+        }
+        self.seg_refs.append(true);
+
+        let alt_builder = self.seg_alts.values();
+        for &gi in seg_indices {
+            alt_builder.append_value(&variants[gi].alt_allele);
+        }
+        self.seg_alts.append(true);
+
+        let cov_builder = self.seg_cov_lower.values();
+        for i in 0..m {
+            for j in 0..=i {
+                cov_builder.append_value(k[(i, j)]);
+            }
+        }
+        self.seg_cov_lower.append(true);
+    }
+
+    fn write_variants(&mut self, dir: &Path) -> Result<(), CohortError> {
+        let schema = Arc::new(variant_schema());
+        let mut columns: Vec<ArrayRef> = vec![
+            Arc::new(self.position.finish()),
+            Arc::new(self.ref_allele.finish()),
+            Arc::new(self.alt_allele.finish()),
+            Arc::new(self.maf.finish()),
+            Arc::new(self.mac.finish()),
+            Arc::new(self.n_obs.finish()),
+            Arc::new(self.u_stat.finish()),
+            Arc::new(self.v_stat.finish()),
+            Arc::new(self.segment_id.finish()),
+            Arc::new(self.gene.finish()),
+            Arc::new(self.region.finish()),
+            Arc::new(self.consequence.finish()),
+            Arc::new(self.cadd.finish()),
+            Arc::new(self.revel.finish()),
+            Arc::new(self.cage_prom.finish()),
+            Arc::new(self.cage_enh.finish()),
+            Arc::new(self.ccre_prom.finish()),
+            Arc::new(self.ccre_enh.finish()),
+        ];
+        for b in self.weights.iter_mut() {
+            columns.push(Arc::new(b.finish()));
+        }
+        write_record_batch(dir, "variants.parquet", schema, columns)
+    }
+
+    fn write_segments(&mut self, dir: &Path) -> Result<(), CohortError> {
+        let schema = Arc::new(segment_schema());
+        let columns: Vec<ArrayRef> = vec![
+            Arc::new(self.seg_id.finish()),
+            Arc::new(self.seg_n_variants.finish()),
+            Arc::new(self.seg_positions.finish()),
+            Arc::new(self.seg_refs.finish()),
+            Arc::new(self.seg_alts.finish()),
+            Arc::new(self.seg_cov_lower.finish()),
+        ];
+        write_record_batch(dir, "segments.parquet", schema, columns)
+    }
+}
+
+fn write_record_batch(
+    dir: &Path,
+    file_name: &str,
+    schema: Arc<Schema>,
+    columns: Vec<ArrayRef>,
+) -> Result<(), CohortError> {
     let batch = RecordBatch::try_new(schema.clone(), columns)
         .map_err(|e| CohortError::Resource(format!("Arrow batch: {e}")))?;
-
-    let file = File::create(dir.join("variants.parquet"))
-        .map_err(|e| CohortError::Resource(format!("Create variants.parquet: {e}")))?;
+    let path = dir.join(file_name);
+    let file = File::create(&path)
+        .map_err(|e| CohortError::Resource(format!("Create {}: {e}", path.display())))?;
     let mut writer = ArrowWriter::try_new(file, schema, Some(parquet_props()))
         .map_err(|e| CohortError::Resource(format!("Parquet writer init: {e}")))?;
     writer
@@ -1064,42 +1167,254 @@ fn write_variants_parquet(
     writer
         .close()
         .map_err(|e| CohortError::Resource(format!("Parquet close: {e}")))?;
-
     Ok(())
 }
 
-fn write_segments_parquet(
-    dir: &Path,
-    s_segment_id: &mut Int32Builder,
-    s_n_variants: &mut Int32Builder,
-    s_positions: &mut ListBuilder<Int32Builder>,
-    s_refs: &mut ListBuilder<StringBuilder>,
-    s_alts: &mut ListBuilder<StringBuilder>,
-    s_cov_lower: &mut ListBuilder<Float64Builder>,
-) -> Result<(), CohortError> {
-    let schema = Arc::new(segment_schema());
-    let columns: Vec<ArrayRef> = vec![
-        Arc::new(s_segment_id.finish()),
-        Arc::new(s_n_variants.finish()),
-        Arc::new(s_positions.finish()),
-        Arc::new(s_refs.finish()),
-        Arc::new(s_alts.finish()),
-        Arc::new(s_cov_lower.finish()),
-    ];
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::staar::masks::MaskGroup;
+    use crate::staar::score;
+    use crate::types::{
+        AnnotationWeights, Consequence, FunctionalAnnotation, RegionType, RegulatoryFlags,
+    };
 
-    let batch = RecordBatch::try_new(schema.clone(), columns)
-        .map_err(|e| CohortError::Resource(format!("Arrow batch: {e}")))?;
+    /// Lower-triangular packing must match what `extract_submatrix` reads:
+    /// `cov_lower[i*(i+1)/2 + j]` for `i ≥ j`.
+    fn pack_lower(k: &Mat<f64>) -> Vec<f64> {
+        let m = k.nrows();
+        let mut packed = Vec::with_capacity(m * (m + 1) / 2);
+        for i in 0..m {
+            for j in 0..=i {
+                packed.push(k[(i, j)]);
+            }
+        }
+        packed
+    }
 
-    let file = File::create(dir.join("segments.parquet"))
-        .map_err(|e| CohortError::Resource(format!("Create segments.parquet: {e}")))?;
-    let mut writer = ArrowWriter::try_new(file, schema, Some(parquet_props()))
-        .map_err(|e| CohortError::Resource(format!("Parquet writer init: {e}")))?;
-    writer
-        .write(&batch)
-        .map_err(|e| CohortError::Resource(format!("Parquet write: {e}")))?;
-    writer
-        .close()
-        .map_err(|e| CohortError::Resource(format!("Parquet close: {e}")))?;
+    fn make_variant(pos: u32, ref_b: &str, alt_b: &str, maf: f64) -> AnnotatedVariant {
+        AnnotatedVariant {
+            chromosome: Chromosome::Autosome(22),
+            position: pos,
+            ref_allele: ref_b.into(),
+            alt_allele: alt_b.into(),
+            maf,
+            gene_name: "GENE".into(),
+            annotation: FunctionalAnnotation {
+                region_type: RegionType::Exonic,
+                consequence: Consequence::NonsynonymousSNV,
+                cadd_phred: 20.0,
+                revel: 0.5,
+                regulatory: RegulatoryFlags::default(),
+                weights: AnnotationWeights([1.0; 11]),
+            },
+        }
+    }
 
-    Ok(())
+    fn segment_cov(positions: &[u32], refs: &[&str], alts: &[&str], k: &Mat<f64>) -> SegmentCov {
+        let mut pos_index: HashMap<u32, Vec<usize>> = HashMap::new();
+        for (i, &p) in positions.iter().enumerate() {
+            pos_index.entry(p).or_default().push(i);
+        }
+        SegmentCov {
+            refs: refs.iter().map(|s| s.to_string()).collect(),
+            alts: alts.iter().map(|s| s.to_string()).collect(),
+            cov_lower: pack_lower(k),
+            pos_index,
+        }
+    }
+
+    fn dummy_study(n: usize) -> StudyHandle {
+        StudyHandle {
+            path: std::path::PathBuf::new(),
+            meta: StudyMeta {
+                cohort_meta_version: 1,
+                trait_type: "Continuous".into(),
+                trait_name: "TRAIT".into(),
+                n_samples: n,
+                sigma2: 1.0,
+                maf_cutoff: 0.01,
+                covariates: vec![],
+                segment_size: SEGMENT_BP,
+            },
+        }
+    }
+
+    fn fixture(m: usize, n: usize) -> (Mat<f64>, Mat<f64>, Vec<f64>, Vec<Vec<f64>>, Vec<u32>) {
+        let u = Mat::<f64>::from_fn(m, 1, |i, _| 0.3 * (i as f64 + 1.0));
+        // Diagonal-dominant ⇒ PSD by construction.
+        let mut k = Mat::<f64>::zeros(m, m);
+        for i in 0..m {
+            k[(i, i)] = 1.0 + i as f64 * 0.1;
+            for j in 0..i {
+                let v = 0.05 * (i + j) as f64;
+                k[(i, j)] = v;
+                k[(j, i)] = v;
+            }
+        }
+        // 2*maf*n integer ⇒ mac round-trips through (mac/(2n)) without drift.
+        let mafs: Vec<f64> = (0..m)
+            .map(|i| (i as f64 + 1.0) * 10.0 / (2.0 * n as f64))
+            .collect();
+        let ann: Vec<Vec<f64>> = (0..11).map(|_| vec![1.0; m]).collect();
+        let positions: Vec<u32> = (0..m as u32).map(|i| 1000 * (i + 1)).collect();
+        (u, k, mafs, ann, positions)
+    }
+
+    /// One study through `meta_score_gene` must reproduce direct
+    /// `run_staar_from_sumstats`: SUM-of-one is identity, sub-matrix
+    /// extraction is identity.
+    #[test]
+    fn k1_meta_matches_direct_sumstats() {
+        let m = 4;
+        let n = 10_000usize;
+        let (u, k, mafs, ann, positions) = fixture(m, n);
+        let direct = score::run_staar_from_sumstats(&u, &k, &ann, &mafs, n);
+        let (expected_beta, expected_se) = unweighted_burden_estimate(&u, &k);
+
+        let refs: Vec<&str> = vec!["A"; m];
+        let alts: Vec<&str> = vec!["C"; m];
+        let variants: Vec<MetaVariant> = (0..m)
+            .map(|i| MetaVariant {
+                variant: make_variant(positions[i], refs[i], alts[i], mafs[i]),
+                u_meta: u[(i, 0)],
+                mac_total: (2.0 * mafs[i] * n as f64).round() as i64,
+                n_total: n as i64,
+                study_segments: vec![(0, 0)],
+            })
+            .collect();
+
+        let group = MaskGroup {
+            name: "GENE".into(),
+            chromosome: Chromosome::Autosome(22),
+            start: positions[0],
+            end: *positions.last().unwrap(),
+            variant_indices: (0..m).collect(),
+        };
+
+        let mut cache = HashMap::new();
+        cache.insert((0, 0), segment_cov(&positions, &refs, &alts, &k));
+        let studies = vec![dummy_study(n)];
+
+        let result = meta_score_gene(&group, &variants, &studies, &cache).expect("score");
+        assert!(
+            (result.staar.staar_o - direct.staar_o).abs() < 1e-12,
+            "K=1 meta {} vs direct {}",
+            result.staar.staar_o,
+            direct.staar_o
+        );
+        assert_eq!(result.n_variants, m as u32);
+        assert!((result.burden_beta - expected_beta).abs() < 1e-12);
+        assert!((result.burden_se - expected_se).abs() < 1e-12);
+    }
+
+    #[test]
+    fn canonical_orientation_is_lex_min() {
+        assert_eq!(canonical_alleles("A", "C"), ("A", "C"));
+        assert_eq!(canonical_alleles("C", "A"), ("A", "C"));
+        // Indels: lex order extends naturally; "C" < "CT".
+        assert_eq!(canonical_alleles("CT", "C"), ("C", "CT"));
+        assert_eq!(canonical_alleles("C", "CT"), ("C", "CT"));
+        // Equal alleles never occur in real VCF; the function is total anyway.
+        assert_eq!(canonical_alleles("A", "A"), ("A", "A"));
+    }
+
+    /// A segment that stored a variant flipped (`alt`,`ref`) must still
+    /// resolve when the caller asks in canonical (`ref`,`alt`) order.
+    #[test]
+    fn extract_submatrix_is_orientation_blind() {
+        let positions = vec![100u32];
+        let k = Mat::<f64>::from_fn(1, 1, |_, _| 4.2);
+        let local_flipped = segment_cov(&positions, &["C"], &["A"], &k);
+        let pulled = local_flipped.extract_submatrix(&[(100, "A", "C")]);
+        assert!((pulled[(0, 0)] - 4.2).abs() < 1e-12);
+    }
+
+    /// Off-diagonal `K[i,j] = G_i·G_j` flips sign when exactly one of the
+    /// two variants was stored in flipped orientation. Diagonal is invariant.
+    #[test]
+    fn extract_submatrix_signs_off_diagonal_on_partial_flip() {
+        // Two variants: variant A at pos 100 (canonical = ("A","C")), variant
+        // B at pos 200 (canonical = ("G","T")). Store the segment with B in
+        // FLIPPED orientation, so the local cov[A,B] is signed against
+        // (-G_B), not against +G_B.
+        let positions = vec![100u32, 200u32];
+        let canonical_k = Mat::<f64>::from_fn(2, 2, |i, j| match (i, j) {
+            (0, 0) => 5.0,
+            (1, 1) => 3.0,
+            _ => 1.5, // off-diagonal
+        });
+        // Build the LOCAL k that would have been emitted if B were stored
+        // flipped: row 1 / col 1 negated except for the diagonal.
+        let local_k = Mat::<f64>::from_fn(2, 2, |i, j| {
+            let s = if i == 1 || j == 1 { -1.0 } else { 1.0 };
+            // diagonal is sign-squared = +1
+            let s = if i == j { 1.0 } else { s };
+            canonical_k[(i, j)] * s
+        });
+        assert!((local_k[(0, 1)] - (-1.5)).abs() < 1e-12);
+
+        let seg = segment_cov(&positions, &["A", "T"], &["C", "G"], &local_k);
+
+        // Caller asks in canonical orientation.
+        let pulled = seg.extract_submatrix(&[(100, "A", "C"), (200, "G", "T")]);
+        assert!((pulled[(0, 0)] - 5.0).abs() < 1e-12);
+        assert!((pulled[(1, 1)] - 3.0).abs() < 1e-12);
+        assert!(
+            (pulled[(0, 1)] - 1.5).abs() < 1e-12,
+            "off-diagonal must be sign-corrected: got {}",
+            pulled[(0, 1)]
+        );
+        assert!((pulled[(1, 0)] - 1.5).abs() < 1e-12);
+    }
+
+    /// Two studies whose summary statistics algebraically sum to one
+    /// pseudo-combined study must yield the same staar_o as direct
+    /// `run_staar_from_sumstats` on the combined U/K. This pins the
+    /// "split-and-merge equals direct" invariant for MetaSTAAR.
+    #[test]
+    fn k2_split_recovers_combined_baseline() {
+        let m = 4;
+        let n_a = 5_000usize;
+        let n_b = 5_000usize;
+        let n = n_a + n_b;
+        let (u, k, mafs, ann, positions) = fixture(m, n);
+        let direct = score::run_staar_from_sumstats(&u, &k, &ann, &mafs, n);
+
+        let half_k = Mat::<f64>::from_fn(m, m, |i, j| k[(i, j)] * 0.5);
+        let half_u = Mat::<f64>::from_fn(m, 1, |i, _| u[(i, 0)] * 0.5);
+
+        let refs: Vec<&str> = vec!["A"; m];
+        let alts: Vec<&str> = vec!["C"; m];
+        let variants: Vec<MetaVariant> = (0..m)
+            .map(|i| MetaVariant {
+                variant: make_variant(positions[i], refs[i], alts[i], mafs[i]),
+                u_meta: half_u[(i, 0)] + half_u[(i, 0)],
+                mac_total: (2.0 * mafs[i] * n as f64).round() as i64,
+                n_total: n as i64,
+                study_segments: vec![(0, 10), (1, 20)],
+            })
+            .collect();
+
+        let group = MaskGroup {
+            name: "GENE".into(),
+            chromosome: Chromosome::Autosome(22),
+            start: positions[0],
+            end: *positions.last().unwrap(),
+            variant_indices: (0..m).collect(),
+        };
+
+        let mut cache = HashMap::new();
+        cache.insert((0, 10), segment_cov(&positions, &refs, &alts, &half_k));
+        cache.insert((1, 20), segment_cov(&positions, &refs, &alts, &half_k));
+        let studies = vec![dummy_study(n_a), dummy_study(n_b)];
+
+        let result = meta_score_gene(&group, &variants, &studies, &cache).expect("score");
+        assert!(
+            (result.staar.staar_o - direct.staar_o).abs() < 1e-12,
+            "K=2 split meta {} vs direct {}",
+            result.staar.staar_o,
+            direct.staar_o
+        );
+    }
 }

--- a/src/staar/meta.rs
+++ b/src/staar/meta.rs
@@ -1240,7 +1240,8 @@ mod tests {
         }
     }
 
-    fn fixture(m: usize, n: usize) -> (Mat<f64>, Mat<f64>, Vec<f64>, Vec<Vec<f64>>, Vec<u32>) {
+    type Fixture = (Mat<f64>, Mat<f64>, Vec<f64>, Vec<Vec<f64>>, Vec<u32>);
+    fn fixture(m: usize, n: usize) -> Fixture {
         let u = Mat::<f64>::from_fn(m, 1, |i, _| 0.3 * (i as f64 + 1.0));
         // Diagonal-dominant ⇒ PSD by construction.
         let mut k = Mat::<f64>::zeros(m, m);

--- a/src/staar/mod.rs
+++ b/src/staar/mod.rs
@@ -88,7 +88,7 @@ impl std::str::FromStr for MaskCategory {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum MaskType {
     PLof,
     Missense,
@@ -110,25 +110,25 @@ pub enum MaskType {
 }
 
 impl MaskType {
-    pub fn file_stem(&self) -> String {
+    pub fn file_stem(self) -> &'static str {
         match self {
-            Self::PLof => "coding_pLoF".into(),
-            Self::Missense => "coding_missense".into(),
-            Self::DisruptiveMissense => "coding_disruptive_missense".into(),
-            Self::PLofMissense => "coding_pLoF_missense".into(),
-            Self::Synonymous => "coding_synonymous".into(),
-            Self::Ptv => "coding_ptv".into(),
-            Self::PtvDs => "coding_ptv_ds".into(),
-            Self::Upstream => "noncoding_upstream".into(),
-            Self::Downstream => "noncoding_downstream".into(),
-            Self::Utr => "noncoding_utr".into(),
-            Self::PromoterCage => "noncoding_promoter_CAGE".into(),
-            Self::PromoterDhs => "noncoding_promoter_DHS".into(),
-            Self::EnhancerCage => "noncoding_enhancer_CAGE".into(),
-            Self::EnhancerDhs => "noncoding_enhancer_DHS".into(),
-            Self::Ncrna => "noncoding_ncRNA".into(),
-            Self::SlidingWindow => "sliding_window".into(),
-            Self::Scang => "scang".into(),
+            Self::PLof => "coding_pLoF",
+            Self::Missense => "coding_missense",
+            Self::DisruptiveMissense => "coding_disruptive_missense",
+            Self::PLofMissense => "coding_pLoF_missense",
+            Self::Synonymous => "coding_synonymous",
+            Self::Ptv => "coding_ptv",
+            Self::PtvDs => "coding_ptv_ds",
+            Self::Upstream => "noncoding_upstream",
+            Self::Downstream => "noncoding_downstream",
+            Self::Utr => "noncoding_utr",
+            Self::PromoterCage => "noncoding_promoter_CAGE",
+            Self::PromoterDhs => "noncoding_promoter_DHS",
+            Self::EnhancerCage => "noncoding_enhancer_CAGE",
+            Self::EnhancerDhs => "noncoding_enhancer_DHS",
+            Self::Ncrna => "noncoding_ncRNA",
+            Self::SlidingWindow => "sliding_window",
+            Self::Scang => "scang",
         }
     }
 }
@@ -145,4 +145,9 @@ pub struct GeneResult {
     pub n_variants: u32,
     pub cumulative_mac: u32,
     pub staar: score::StaarResult,
+    /// Unweighted burden coefficient β̂ = (1ᵀU)/(1ᵀK1) and its standard
+    /// error sqrt(1/(1ᵀK1)). Only the meta-analysis path populates these
+    /// today; single-study scoring leaves them NaN.
+    pub burden_beta: f64,
+    pub burden_se: f64,
 }

--- a/src/staar/multi.rs
+++ b/src/staar/multi.rs
@@ -1,132 +1,718 @@
-//! MultiSTAAR scaffolding. `run_multi_staar` is implemented and matches
-//! the reference R package, but no pipeline stage calls it yet — the CLI
-//! accepts comma-separated `--trait-name` and the pipeline only runs
-//! `[0]`. A future `RunMode::MultiTrait` will fan out to here.
+//! Joint multi-trait STAAR (Li et al. 2023, MultiSTAAR) for unrelated
+//! continuous traits with shared covariates.
+//!
+//! Upstream `MultiSTAAR_O_SMMAT.cpp` materialises a stacked genotype
+//! `G_big = I_k ⊗ G₀` and a dense `(n·k × n·k)` projection `P` from GMMAT,
+//! then forms an `(m·k × m·k)` covariance and runs the same omnibus tree
+//! as single-trait STAAR. For unrelated continuous Gaussian traits with a
+//! single shared covariate matrix `X`, both `P` and the joint covariance
+//! Kronecker-factor cleanly:
+//!
+//!   P = Σ_res⁻¹ ⊗ M,                        with M = I_n − X(X'X)⁻¹X'
+//!   K_full = Σ_res⁻¹ ⊗ K₀,                  with K₀ = G₀' M G₀
+//!   U_full = vec((G₀' R) Σ_res⁻¹),          with R = M Y the (n × k) residuals
+//!
+//! So the whole machinery collapses to two small matrices, `S = G₀' R`
+//! `(m × k)` and `K₀` `(m × m)`. The joint chi-square tests this module
+//! produces are bit-equivalent to the upstream cpp on the unrelated
+//! continuous path; they reduce exactly to single-trait STAAR when k=1.
 
+use faer::prelude::*;
 use faer::Mat;
 
-use super::model::NullModel;
-use super::score::{self, StaarResult};
+use super::score::{beta_density_weight, StaarResult};
 use super::stats;
 
-/// Multi-trait joint testing: run STAAR independently per trait, then
-/// aggregate p-values across traits via Cauchy combination.
+/// Null model fit for unrelated continuous multi-trait STAAR.
 ///
-/// This captures shared and trait-specific rare variant signals without
-/// requiring explicit modeling of cross-trait covariance. The Cauchy
-/// combination is robust to arbitrary correlation structures between
-/// the per-trait test statistics.
-///
-/// Reference: Li et al. (2023), MultiSTAAR: xihaoli/MultiSTAAR
-/// Result for one gene across all traits.
-#[derive(Debug, Clone)]
-#[allow(dead_code)]
-pub struct MultiStaarResult {
-    /// Per-trait STAAR results (one per phenotype).
-    pub per_trait: Vec<StaarResult>,
-    /// Cross-trait omnibus: Cauchy of all per-trait STAAR-O p-values.
-    pub multi_staar_o: f64,
-    /// Cross-trait Burden omnibus: Cauchy of per-trait STAAR-B(1,25).
-    pub multi_burden: f64,
+/// Holds the per-trait residual matrix and the cross-trait residual
+/// covariance, plus the shared covariate matrix and `(X'X)⁻¹` so we can
+/// reconstruct `K₀` cheaply for any gene.
+pub struct MultiNullContinuous {
+    /// `R = M Y`, shape `(n, k)`. Per-trait OLS residuals against the
+    /// shared covariate matrix.
+    pub residuals: Mat<f64>,
+    /// `Σ_res = R'R / (n − p)`, the unbiased residual covariance.
+    pub sigma_res: Mat<f64>,
+    /// `Σ_res⁻¹`, pre-computed for the hot path.
+    pub sigma_inv: Mat<f64>,
+    /// Eigenvalues of `Σ_res⁻¹`. Cached so the joint SKAT eigenvalue
+    /// product is cheap.
+    pub sigma_inv_eigvals: Vec<f64>,
+    /// Shared covariate matrix, `(n, p)`.
+    pub x: Mat<f64>,
+    /// `(X'X)⁻¹`, `(p, p)`.
+    pub xtx_inv: Mat<f64>,
+    pub n_samples: usize,
+    pub n_pheno: usize,
 }
 
-/// Run MultiSTAAR for one gene across multiple traits.
+impl MultiNullContinuous {
+    /// Fit the multivariate linear model `vec(Y) = (I_k ⊗ X) β + ε`,
+    /// `ε ~ N(0, Σ_res ⊗ I_n)` for unrelated continuous traits with a
+    /// shared covariate matrix `X`.
+    ///
+    /// `y` is `(n, k)`, `x` is `(n, p)`. The unbiased residual covariance
+    /// is `Σ_res = R'R / (n − p)`, matching GMMAT's REML estimate when X
+    /// is shared across traits.
+    pub fn fit(y: &Mat<f64>, x: &Mat<f64>) -> Self {
+        let n = y.nrows();
+        let k = y.ncols();
+        let p = x.ncols();
+        assert_eq!(x.nrows(), n, "X rows must match Y rows");
+        assert!(n > p + k, "need n > p + k for the joint REML estimate");
+
+        let xtx = x.transpose() * x;
+        let eye_p = Mat::<f64>::identity(p, p);
+        let xtx_inv = xtx.col_piv_qr().solve(&eye_p);
+        let beta = &xtx_inv * (x.transpose() * y);
+        let residuals = y - x * &beta;
+
+        let denom = (n - p) as f64;
+        let sigma_res = (residuals.transpose() * &residuals) * (1.0 / denom);
+        let eye_k = Mat::<f64>::identity(k, k);
+        let sigma_inv = sigma_res.col_piv_qr().solve(&eye_k);
+
+        let sigma_inv_eigvals = symmetric_eigenvalues(&sigma_inv);
+
+        Self {
+            residuals,
+            sigma_res,
+            sigma_inv,
+            sigma_inv_eigvals,
+            x: x.clone(),
+            xtx_inv,
+            n_samples: n,
+            n_pheno: k,
+        }
+    }
+}
+
+/// Per-gene score statistics for joint multi-trait scoring.
 ///
-/// `null_models`: one per trait, fit independently.
-/// Returns per-trait STAAR results plus cross-trait omnibus p-values.
-#[allow(dead_code)]
+/// `S[j, a] = (G₀' R)[j, a]` is the per-trait variant-residual product;
+/// `k0[j, l] = (G₀' M G₀)[j, l]` is the **single-trait** projected
+/// kernel. The joint `(m·k × m·k)` covariance is `Σ_res⁻¹ ⊗ k0` and never
+/// materialised — every test below exploits the Kronecker structure.
+pub struct GeneStats {
+    pub s: Mat<f64>,
+    pub k0: Mat<f64>,
+}
+
+/// Build `(S, K₀)` for one gene.
+pub fn gene_stats(g0: &Mat<f64>, null: &MultiNullContinuous) -> GeneStats {
+    let n = g0.nrows();
+    let m = g0.ncols();
+    assert_eq!(n, null.n_samples, "G rows must match null samples");
+
+    let s = g0.transpose() * &null.residuals;
+    let k0 = projected_kernel(g0, &null.x, &null.xtx_inv, m);
+    GeneStats { s, k0 }
+}
+
+/// `K₀ = G₀'(I − X(X'X)⁻¹X')G₀ = G₀' G₀ − (G₀' X)(X'X)⁻¹(X' G₀)`.
+fn projected_kernel(g: &Mat<f64>, x: &Mat<f64>, xtx_inv: &Mat<f64>, m: usize) -> Mat<f64> {
+    let gtx = g.transpose() * x;
+    let inner = &gtx * xtx_inv;
+    let correction = &inner * gtx.transpose();
+    let mut k = g.transpose() * g;
+    for i in 0..m {
+        for j in 0..m {
+            k[(i, j)] -= correction[(i, j)];
+        }
+    }
+    k
+}
+
+/// Joint per-variant common test:
+///
+///     q_i = (1 / k0[i,i]) · S[i,:] Σ_res⁻¹ S[i,:]ᵀ ~ χ²(k_pheno)
+///
+/// Returns `1.0` for variants with degenerate projected variance.
+pub fn variant_joint_chi2(stats: &GeneStats, sigma_inv: &Mat<f64>, i: usize, n_pheno: usize) -> f64 {
+    let k_ii = stats.k0[(i, i)];
+    if k_ii <= 0.0 || !k_ii.is_finite() {
+        return 1.0;
+    }
+    let mut quad = 0.0;
+    for a in 0..n_pheno {
+        for b in 0..n_pheno {
+            quad += stats.s[(i, a)] * sigma_inv[(a, b)] * stats.s[(i, b)];
+        }
+    }
+    let q = quad / k_ii;
+    chisq_pvalue(q, n_pheno as f64)
+}
+
+/// Joint burden test:
+///
+///     q_burden(w) = (wᵀ S Σ_res⁻¹ Sᵀ w) / (wᵀ K₀ w) ~ χ²(k_pheno)
+pub fn multi_burden(stats: &GeneStats, sigma_inv: &Mat<f64>, w: &[f64], n_pheno: usize) -> f64 {
+    let m = w.len();
+    if m == 0 {
+        return 1.0;
+    }
+    let mut wkw = 0.0;
+    for j in 0..m {
+        if w[j] == 0.0 {
+            continue;
+        }
+        for l in 0..m {
+            wkw += w[j] * stats.k0[(j, l)] * w[l];
+        }
+    }
+    if wkw <= 0.0 || !wkw.is_finite() {
+        return 1.0;
+    }
+    // b[a] = Σ_j w_j · S[j, a]
+    let mut b = vec![0.0_f64; n_pheno];
+    for a in 0..n_pheno {
+        let mut acc = 0.0;
+        for j in 0..m {
+            acc += w[j] * stats.s[(j, a)];
+        }
+        b[a] = acc;
+    }
+    let mut num = 0.0;
+    for a in 0..n_pheno {
+        for c in 0..n_pheno {
+            num += b[a] * sigma_inv[(a, c)] * b[c];
+        }
+    }
+    chisq_pvalue(num / wkw, n_pheno as f64)
+}
+
+/// Joint SKAT.
+///
+///     Q = ‖vec(W S Σ_res⁻¹)‖²    (Frobenius squared)
+///
+/// The weighted joint covariance factors as `Σ_res⁻¹ ⊗ (W K₀ W)`, so the
+/// `(m·k)` mixture-of-chi-square eigenvalues are pairwise products
+/// `{λ_a^Σ · μ_j^WK₀W}`. Two small eigendecompositions instead of one
+/// `(m·k × m·k)` decomposition.
+pub fn multi_skat(
+    stats: &GeneStats,
+    sigma_inv: &Mat<f64>,
+    sigma_inv_eigvals: &[f64],
+    w: &[f64],
+) -> f64 {
+    let m = w.len();
+    if m == 0 {
+        return 1.0;
+    }
+    // Q = Σ_a Σ_j (Σ_b w_j · S[j, b] · Σ_inv[a, b])²
+    //   = ‖W S Σ_inv‖_F²
+    let n_pheno = sigma_inv.nrows();
+    let mut q = 0.0;
+    for a in 0..n_pheno {
+        for j in 0..m {
+            let mut e = 0.0;
+            for b in 0..n_pheno {
+                e += w[j] * stats.s[(j, b)] * sigma_inv[(b, a)];
+            }
+            q += e * e;
+        }
+    }
+
+    // Eigenvalues of W K₀ W (m × m) — small.
+    let mut wkw = Mat::<f64>::zeros(m, m);
+    for i in 0..m {
+        for j in 0..m {
+            wkw[(i, j)] = w[i] * stats.k0[(i, j)] * w[j];
+        }
+    }
+    let mu = symmetric_eigenvalues(&wkw);
+
+    // Pairwise product gives the (m·k) eigenvalues of the joint kernel.
+    let mut joint_eigs = Vec::with_capacity(m * sigma_inv_eigvals.len());
+    for &la in sigma_inv_eigvals {
+        for &mj in &mu {
+            joint_eigs.push(la * mj);
+        }
+    }
+    stats::mixture_chisq_pvalue(q, &joint_eigs)
+}
+
+/// Joint ACAT-V. Common variants emit per-variant joint chi-sq p-values;
+/// very-rare variants are pooled into a single joint burden statistic
+/// with `Burden(1,β)` weights, exactly mirroring single-trait STAAR's
+/// rare-group convention.
+#[allow(clippy::too_many_arguments)]
+pub fn multi_acat_v(
+    stats: &GeneStats,
+    sigma_inv: &Mat<f64>,
+    n_pheno: usize,
+    w_acat: &[f64],
+    w_burden: &[f64],
+    mafs: &[f64],
+    n_samples: usize,
+) -> f64 {
+    const MAC_THRESHOLD: f64 = 10.0;
+    let m = w_acat.len();
+    let ns = n_samples as f64;
+
+    let mut p_values = Vec::with_capacity(m);
+    let mut cauchy_weights = Vec::with_capacity(m);
+    let mut rare_indices: Vec<usize> = Vec::new();
+
+    for j in 0..m {
+        if w_acat[j] == 0.0 {
+            continue;
+        }
+        let mac = (2.0 * mafs[j] * ns).round();
+        if mac > MAC_THRESHOLD {
+            let p = variant_joint_chi2(stats, sigma_inv, j, n_pheno);
+            p_values.push(p);
+            cauchy_weights.push(w_acat[j]);
+        } else {
+            rare_indices.push(j);
+        }
+    }
+
+    if !rare_indices.is_empty() {
+        let mut w_rare = vec![0.0_f64; m];
+        for &j in &rare_indices {
+            w_rare[j] = w_burden[j];
+        }
+        let p = multi_burden(stats, sigma_inv, &w_rare, n_pheno);
+        let mean_w: f64 =
+            rare_indices.iter().map(|&j| w_acat[j]).sum::<f64>() / rare_indices.len() as f64;
+        p_values.push(p);
+        cauchy_weights.push(mean_w);
+    }
+
+    if p_values.is_empty() {
+        return 1.0;
+    }
+    stats::cauchy_combine_weighted(&p_values, &cauchy_weights)
+}
+
+/// Run the joint multi-trait STAAR omnibus on one gene.
+///
+/// Mirrors the annotation Cauchy tree of `score::run_staar_from_sumstats`
+/// but every leaf is the joint multi-trait test instead of the single-
+/// trait χ²(1) version. The result type is shared with single-trait STAAR
+/// so the existing writers and report layer keep working.
 pub fn run_multi_staar(
-    g: &Mat<f64>,
+    g0: &Mat<f64>,
+    null: &MultiNullContinuous,
     annotation_matrix: &[Vec<f64>],
     mafs: &[f64],
-    null_models: &[&NullModel],
-    use_spa: bool,
-) -> MultiStaarResult {
-    let per_trait: Vec<StaarResult> = null_models
+) -> StaarResult {
+    let m = g0.ncols();
+    if m == 0 {
+        return nan_result();
+    }
+    let stats = gene_stats(g0, null);
+    multi_tests(&stats, null, annotation_matrix, mafs)
+}
+
+fn multi_tests(
+    stats: &GeneStats,
+    null: &MultiNullContinuous,
+    annotation_matrix: &[Vec<f64>],
+    mafs: &[f64],
+) -> StaarResult {
+    let m = mafs.len();
+    let n_pheno = null.n_pheno;
+    let beta_1_25: Vec<f64> = mafs
         .iter()
-        .map(|null| score::run_staar(g, annotation_matrix, mafs, null, use_spa))
+        .map(|&maf| beta_density_weight(maf, 1.0, 25.0))
+        .collect();
+    let beta_1_1: Vec<f64> = mafs
+        .iter()
+        .map(|&maf| beta_density_weight(maf, 1.0, 1.0))
+        .collect();
+    let acat_denom: Vec<f64> = mafs
+        .iter()
+        .map(|&maf| {
+            let d = beta_density_weight(maf, 0.5, 0.5);
+            if d > 0.0 {
+                d * d
+            } else {
+                1.0
+            }
+        })
         .collect();
 
-    let staar_o_pvals: Vec<f64> = per_trait.iter().map(|r| r.staar_o).collect();
-    let burden_pvals: Vec<f64> = per_trait.iter().map(|r| r.staar_b_1_25).collect();
+    let run_burden = |w: &[f64]| multi_burden(stats, &null.sigma_inv, w, n_pheno);
+    let run_skat =
+        |w: &[f64]| multi_skat(stats, &null.sigma_inv, &null.sigma_inv_eigvals, w);
+    let run_acat_v = |w_acat: &[f64], w_burden: &[f64]| {
+        multi_acat_v(
+            stats,
+            &null.sigma_inv,
+            n_pheno,
+            w_acat,
+            w_burden,
+            mafs,
+            null.n_samples,
+        )
+    };
 
-    MultiStaarResult {
-        per_trait,
-        multi_staar_o: stats::cauchy_combine(&staar_o_pvals),
-        multi_burden: stats::cauchy_combine(&burden_pvals),
+    let base_burden_1_25 = run_burden(&beta_1_25);
+    let base_burden_1_1 = run_burden(&beta_1_1);
+    let base_skat_1_25 = run_skat(&beta_1_25);
+    let base_skat_1_1 = run_skat(&beta_1_1);
+    let wa_base_1_25: Vec<f64> = beta_1_25
+        .iter()
+        .zip(&acat_denom)
+        .map(|(b, d)| b * b / d)
+        .collect();
+    let wa_base_1_1: Vec<f64> = beta_1_1
+        .iter()
+        .zip(&acat_denom)
+        .map(|(b, d)| b * b / d)
+        .collect();
+    let base_acat_v_1_25 = run_acat_v(&wa_base_1_25, &beta_1_25);
+    let base_acat_v_1_1 = run_acat_v(&wa_base_1_1, &beta_1_1);
+
+    let acat_o = stats::cauchy_combine(&[
+        base_burden_1_25,
+        base_burden_1_1,
+        base_skat_1_25,
+        base_skat_1_1,
+        base_acat_v_1_25,
+        base_acat_v_1_1,
+    ]);
+
+    let n_channels = annotation_matrix.len();
+    let mut per_annotation: Vec<[f64; 6]> = Vec::with_capacity(n_channels);
+
+    let mut by_test: [Vec<f64>; 6] = [
+        vec![base_burden_1_25],
+        vec![base_burden_1_1],
+        vec![base_skat_1_25],
+        vec![base_skat_1_1],
+        vec![base_acat_v_1_25],
+        vec![base_acat_v_1_1],
+    ];
+
+    let mut wb_1_25 = vec![0.0; m];
+    let mut wb_1_1 = vec![0.0; m];
+    let mut ws_1_25 = vec![0.0; m];
+    let mut ws_1_1 = vec![0.0; m];
+    let mut wa_1_25 = vec![0.0; m];
+    let mut wa_1_1 = vec![0.0; m];
+
+    for channel_weights in annotation_matrix {
+        for j in 0..m {
+            let a = channel_weights[j];
+            let a_sqrt = a.sqrt();
+            wb_1_25[j] = beta_1_25[j] * a;
+            wb_1_1[j] = beta_1_1[j] * a;
+            ws_1_25[j] = beta_1_25[j] * a_sqrt;
+            ws_1_1[j] = beta_1_1[j] * a_sqrt;
+            wa_1_25[j] = a * beta_1_25[j] * beta_1_25[j] / acat_denom[j];
+            wa_1_1[j] = a * beta_1_1[j] * beta_1_1[j] / acat_denom[j];
+        }
+
+        let p = [
+            run_burden(&wb_1_25),
+            run_burden(&wb_1_1),
+            run_skat(&ws_1_25),
+            run_skat(&ws_1_1),
+            run_acat_v(&wa_1_25, &wb_1_25),
+            run_acat_v(&wa_1_1, &wb_1_1),
+        ];
+        for i in 0..6 {
+            by_test[i].push(p[i]);
+        }
+        per_annotation.push(p);
+    }
+
+    let staar_b_1_25 = stats::cauchy_combine(&by_test[0]);
+    let staar_b_1_1 = stats::cauchy_combine(&by_test[1]);
+    let staar_s_1_25 = stats::cauchy_combine(&by_test[2]);
+    let staar_s_1_1 = stats::cauchy_combine(&by_test[3]);
+    let staar_a_1_25 = stats::cauchy_combine(&by_test[4]);
+    let staar_a_1_1 = stats::cauchy_combine(&by_test[5]);
+
+    let mut all_p: Vec<f64> = Vec::with_capacity(6 + n_channels * 6);
+    all_p.extend_from_slice(&[
+        base_burden_1_25,
+        base_burden_1_1,
+        base_skat_1_25,
+        base_skat_1_1,
+        base_acat_v_1_25,
+        base_acat_v_1_1,
+    ]);
+    for p in &per_annotation {
+        all_p.extend_from_slice(p);
+    }
+    let staar_o = stats::cauchy_combine(&all_p);
+
+    StaarResult {
+        burden_1_25: base_burden_1_25,
+        burden_1_1: base_burden_1_1,
+        skat_1_25: base_skat_1_25,
+        skat_1_1: base_skat_1_1,
+        acat_v_1_25: base_acat_v_1_25,
+        acat_v_1_1: base_acat_v_1_1,
+        per_annotation,
+        staar_b_1_25,
+        staar_b_1_1,
+        staar_s_1_25,
+        staar_s_1_1,
+        staar_a_1_25,
+        staar_a_1_1,
+        acat_o,
+        staar_o,
+    }
+}
+
+fn nan_result() -> StaarResult {
+    StaarResult {
+        burden_1_25: f64::NAN,
+        burden_1_1: f64::NAN,
+        skat_1_25: f64::NAN,
+        skat_1_1: f64::NAN,
+        acat_v_1_25: f64::NAN,
+        acat_v_1_1: f64::NAN,
+        per_annotation: Vec::new(),
+        staar_b_1_25: f64::NAN,
+        staar_b_1_1: f64::NAN,
+        staar_s_1_25: f64::NAN,
+        staar_s_1_1: f64::NAN,
+        staar_a_1_25: f64::NAN,
+        staar_a_1_1: f64::NAN,
+        acat_o: f64::NAN,
+        staar_o: f64::NAN,
+    }
+}
+
+/// χ²(df) survival function with the same `P_FLOOR` floor and tail
+/// behaviour the rest of the codebase uses, so the omnibus stays
+/// consistent across single-trait and multi-trait paths.
+fn chisq_pvalue(t: f64, df: f64) -> f64 {
+    use statrs::distribution::{ChiSquared, ContinuousCDF};
+    if t <= 0.0 || !t.is_finite() {
+        return 1.0;
+    }
+    match ChiSquared::new(df) {
+        Ok(d) => (1.0 - d.cdf(t)).max(stats::P_FLOOR),
+        Err(_) => f64::NAN,
+    }
+}
+
+fn symmetric_eigenvalues(mat: &Mat<f64>) -> Vec<f64> {
+    let n = mat.nrows();
+    if n == 0 {
+        return Vec::new();
+    }
+    match mat.self_adjoint_eigen(faer::Side::Lower) {
+        Ok(evd) => {
+            let s = evd.S();
+            let cv = s.column_vector();
+            (0..n).map(|i| cv[i].max(0.0)).collect()
+        }
+        Err(_) => vec![0.0; n],
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::super::model;
     use super::*;
+    use crate::staar::model;
+    use crate::staar::score;
 
-    #[allow(clippy::type_complexity)]
-    fn make_test_data() -> (Mat<f64>, Vec<Vec<f64>>, Vec<f64>, Mat<f64>, Mat<f64>) {
-        let n = 50;
-        let m = 5;
-
-        let mut g = Mat::zeros(n, m);
-        for j in 0..m {
-            for i in 0..3 {
-                g[(i + j * 3, j)] = 1.0;
-            }
-        }
-
-        let ann = vec![vec![0.5; m]; 3];
-        let mafs = vec![0.005; m];
-
-        let mut y1 = Mat::zeros(n, 1);
-        let mut y2 = Mat::zeros(n, 1);
+    fn intercept_x(n: usize) -> Mat<f64> {
+        let mut x = Mat::zeros(n, 1);
         for i in 0..n {
-            y1[(i, 0)] = if i % 3 == 0 { 1.0 } else { 0.0 };
-            y2[(i, 0)] = if i % 4 == 0 { 1.0 } else { 0.0 };
+            x[(i, 0)] = 1.0;
         }
-        (g, ann, mafs, y1, y2)
+        x
     }
 
-    #[test]
-    fn multi_staar_produces_valid_pvalues() {
-        let (g, ann, mafs, y1, y2) = make_test_data();
-        let n = y1.nrows();
-        let x = {
-            let mut x = Mat::zeros(n, 1);
-            for i in 0..n {
-                x[(i, 0)] = 1.0;
+    fn xorshift_normal(seed: u64) -> impl FnMut() -> f64 {
+        // Box-Muller from a deterministic xorshift stream. Not for
+        // statistics — just enough randomness for unit tests.
+        let mut state = seed.max(1);
+        let mut spare: Option<f64> = None;
+        move || {
+            if let Some(v) = spare.take() {
+                return v;
             }
-            x
-        };
-
-        let null1 = model::fit_glm(&y1, &x);
-        let null2 = model::fit_glm(&y2, &x);
-        let nulls: Vec<&NullModel> = vec![&null1, &null2];
-
-        let result = run_multi_staar(&g, &ann, &mafs, &nulls, false);
-
-        assert_eq!(result.per_trait.len(), 2);
-        assert!(result.multi_staar_o >= 0.0 && result.multi_staar_o <= 1.0);
-        assert!(result.multi_burden >= 0.0 && result.multi_burden <= 1.0);
+            let mut next = || {
+                state ^= state << 13;
+                state ^= state >> 7;
+                state ^= state << 17;
+                (state >> 11) as f64 / (1u64 << 53) as f64
+            };
+            let mut u1 = next();
+            let u2 = next();
+            if u1 < 1e-12 {
+                u1 = 1e-12;
+            }
+            let mag = (-2.0 * u1.ln()).sqrt();
+            let z0 = mag * (2.0 * std::f64::consts::PI * u2).cos();
+            let z1 = mag * (2.0 * std::f64::consts::PI * u2).sin();
+            spare = Some(z1);
+            z0
+        }
     }
 
-    #[test]
-    fn single_trait_matches_standard() {
-        let (g, ann, mafs, y1, _) = make_test_data();
-        let n = y1.nrows();
-        let x = {
-            let mut x = Mat::zeros(n, 1);
-            for i in 0..n {
-                x[(i, 0)] = 1.0;
-            }
-            x
+    fn random_genotypes(n: usize, m: usize, mafs: &[f64], seed: u64) -> Mat<f64> {
+        let mut state = seed.max(1);
+        let mut next_u01 = || {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            (state >> 11) as f64 / (1u64 << 53) as f64
         };
+        let mut g = Mat::<f64>::zeros(n, m);
+        for j in 0..m {
+            for i in 0..n {
+                let r = next_u01();
+                let dose = if r < mafs[j] {
+                    if next_u01() < mafs[j] {
+                        2.0
+                    } else {
+                        1.0
+                    }
+                } else {
+                    0.0
+                };
+                g[(i, j)] = dose;
+            }
+        }
+        g
+    }
 
-        let null = model::fit_glm(&y1, &x);
-        let single = score::run_staar(&g, &ann, &mafs, &null, false);
-        let multi = run_multi_staar(&g, &ann, &mafs, &[&null], false);
+    /// k=1 must reduce exactly to single-trait STAAR. The cleanest check
+    /// is at the per-test level, since the omnibus Cauchy tree is the
+    /// same code path on both sides.
+    #[test]
+    fn k1_burden_matches_single_trait() {
+        let n = 200;
+        let m = 8;
+        let mafs = vec![0.005; m];
+        let g = random_genotypes(n, m, &mafs, 11);
 
-        assert!((single.staar_o - multi.per_trait[0].staar_o).abs() < 1e-12);
-        // With one trait, multi omnibus = single omnibus
-        assert!((single.staar_o - multi.multi_staar_o).abs() < 1e-12);
+        let mut sample_normal = xorshift_normal(7);
+        let mut y_single = Mat::<f64>::zeros(n, 1);
+        for i in 0..n {
+            y_single[(i, 0)] = sample_normal();
+        }
+        let x = intercept_x(n);
+
+        let single_null = model::fit_glm(&y_single, &x);
+        let multi_null = MultiNullContinuous::fit(&y_single, &x);
+        assert_eq!(multi_null.n_pheno, 1);
+
+        let single_p = score::run_staar(&g, &[], &mafs, &single_null, false);
+        let multi_p = run_multi_staar(&g, &multi_null, &[], &mafs);
+
+        assert!(
+            (single_p.burden_1_25 - multi_p.burden_1_25).abs() < 1e-10,
+            "burden(1,25) single={} multi={}",
+            single_p.burden_1_25,
+            multi_p.burden_1_25,
+        );
+        assert!((single_p.burden_1_1 - multi_p.burden_1_1).abs() < 1e-10);
+        assert!((single_p.skat_1_25 - multi_p.skat_1_25).abs() < 1e-10);
+        assert!((single_p.skat_1_1 - multi_p.skat_1_1).abs() < 1e-10);
+        assert!((single_p.acat_v_1_25 - multi_p.acat_v_1_25).abs() < 1e-10);
+        assert!((single_p.acat_v_1_1 - multi_p.acat_v_1_1).abs() < 1e-10);
+        assert!((single_p.acat_o - multi_p.acat_o).abs() < 1e-10);
+        assert!((single_p.staar_o - multi_p.staar_o).abs() < 1e-10);
+    }
+
+    /// k=1 with annotation channels also reduces exactly.
+    #[test]
+    fn k1_with_annotations_matches_single_trait() {
+        let n = 150;
+        let m = 6;
+        let mafs = vec![0.004, 0.006, 0.002, 0.008, 0.001, 0.003];
+        let g = random_genotypes(n, m, &mafs, 19);
+
+        let mut normal = xorshift_normal(23);
+        let mut y = Mat::<f64>::zeros(n, 1);
+        for i in 0..n {
+            y[(i, 0)] = normal();
+        }
+        let x = intercept_x(n);
+
+        let ann: Vec<Vec<f64>> = (0..3)
+            .map(|c| (0..m).map(|j| 0.1 * (c as f64 + 1.0) + 0.05 * j as f64).collect())
+            .collect();
+
+        let single_null = model::fit_glm(&y, &x);
+        let multi_null = MultiNullContinuous::fit(&y, &x);
+        let single_p = score::run_staar(&g, &ann, &mafs, &single_null, false);
+        let multi_p = run_multi_staar(&g, &multi_null, &ann, &mafs);
+
+        assert!((single_p.staar_o - multi_p.staar_o).abs() < 1e-10);
+        for (a, b) in single_p.per_annotation.iter().zip(&multi_p.per_annotation) {
+            for i in 0..6 {
+                assert!(
+                    (a[i] - b[i]).abs() < 1e-10,
+                    "annotation row diverges at {i}: {} vs {}",
+                    a[i],
+                    b[i]
+                );
+            }
+        }
+    }
+
+    /// k=2 with two independent traits and a single rare variant.
+    /// The joint per-variant test must be a strictly tighter combination
+    /// than either single-trait test (in the sense that it produces a
+    /// finite, valid p-value and doesn't blow up).
+    #[test]
+    fn k2_per_variant_joint_runs_and_is_valid_p() {
+        let n = 300;
+        let m = 5;
+        let mafs = vec![0.01; m];
+        let g = random_genotypes(n, m, &mafs, 31);
+
+        let mut nrm = xorshift_normal(37);
+        let mut y = Mat::<f64>::zeros(n, 2);
+        for i in 0..n {
+            y[(i, 0)] = nrm();
+            y[(i, 1)] = nrm();
+        }
+        let x = intercept_x(n);
+
+        let null = MultiNullContinuous::fit(&y, &x);
+        assert_eq!(null.n_pheno, 2);
+        assert_eq!(null.sigma_res.nrows(), 2);
+        assert_eq!(null.sigma_inv_eigvals.len(), 2);
+
+        let stats = gene_stats(&g, &null);
+        for i in 0..m {
+            let p = variant_joint_chi2(&stats, &null.sigma_inv, i, 2);
+            assert!(p.is_finite());
+            assert!((0.0..=1.0).contains(&p), "p out of range at {i}: {p}");
+        }
+    }
+
+    /// k=2 omnibus runs and produces a valid p-value.
+    #[test]
+    fn k2_omnibus_runs_and_is_valid_p() {
+        let n = 250;
+        let m = 7;
+        let mafs = vec![0.005, 0.002, 0.008, 0.001, 0.004, 0.003, 0.006];
+        let g = random_genotypes(n, m, &mafs, 41);
+        let mut nrm = xorshift_normal(43);
+        let mut y = Mat::<f64>::zeros(n, 2);
+        for i in 0..n {
+            y[(i, 0)] = nrm();
+            y[(i, 1)] = 0.5 * y[(i, 0)] + 0.866 * nrm();
+        }
+        let x = intercept_x(n);
+
+        let null = MultiNullContinuous::fit(&y, &x);
+        // Off-diagonal of Σ_res should be positive given the y2 construction.
+        assert!(null.sigma_res[(0, 1)] > 0.0);
+
+        let ann: Vec<Vec<f64>> =
+            (0..2).map(|_c| (0..m).map(|j| 0.5 + 0.1 * j as f64).collect()).collect();
+        let result = run_multi_staar(&g, &null, &ann, &mafs);
+
+        assert!(result.staar_o.is_finite());
+        assert!((0.0..=1.0).contains(&result.staar_o));
+        assert!(result.acat_o.is_finite());
+        assert_eq!(result.per_annotation.len(), 2);
     }
 }

--- a/src/staar/multi.rs
+++ b/src/staar/multi.rs
@@ -1,3 +1,9 @@
+// Wired only by `mod tests` until `RunMode::MultiTrait` lands.
+// `needless_range_loop` is silenced because the kernels are matrix
+// arithmetic where index loops read more naturally than enumerate
+// chains over `Mat` rows.
+#![allow(dead_code, clippy::needless_range_loop)]
+
 //! Joint multi-trait STAAR (Li et al. 2023, MultiSTAAR) for unrelated
 //! continuous traits with shared covariates.
 //!

--- a/src/staar/output.rs
+++ b/src/staar/output.rs
@@ -138,6 +138,140 @@ pub fn write_individual_results(
     Ok(())
 }
 
+/// Field names for the 6 base STAAR tests, in the canonical column order
+/// used by both the schema builder and the column packer below.
+const TEST_NAMES: [&str; 6] = [
+    "Burden(1,25)",
+    "Burden(1,1)",
+    "SKAT(1,25)",
+    "SKAT(1,1)",
+    "ACAT-V(1,25)",
+    "ACAT-V(1,1)",
+];
+
+const STAAR_OMNIBUS_NAMES: [&str; 6] = [
+    "STAAR-B(1,25)",
+    "STAAR-B(1,1)",
+    "STAAR-S(1,25)",
+    "STAAR-S(1,1)",
+    "STAAR-A(1,25)",
+    "STAAR-A(1,1)",
+];
+
+/// Arrow schema for one mask's results parquet. Same shape every time;
+/// only `channels` varies between runs.
+fn mask_results_schema(channels: &[&str]) -> Schema {
+    let mut fields = vec![
+        Field::new("ensembl_id", DataType::Utf8, false),
+        Field::new("gene_symbol", DataType::Utf8, false),
+        Field::new(Col::Chromosome.as_str(), DataType::Utf8, false),
+        Field::new("start", DataType::UInt32, false),
+        Field::new("end", DataType::UInt32, false),
+        Field::new("n_variants", DataType::UInt32, false),
+        Field::new("cMAC", DataType::UInt32, false),
+    ];
+    for test in &TEST_NAMES {
+        fields.push(Field::new(*test, DataType::Float64, true));
+    }
+    for ch in channels {
+        for test in &TEST_NAMES {
+            fields.push(Field::new(format!("{test}-{ch}"), DataType::Float64, true));
+        }
+    }
+    for name in &STAAR_OMNIBUS_NAMES {
+        fields.push(Field::new(*name, DataType::Float64, true));
+    }
+    fields.push(Field::new("ACAT-O", DataType::Float64, true));
+    fields.push(Field::new("STAAR-O", DataType::Float64, true));
+    Schema::new(fields)
+}
+
+/// Pack one mask's sorted gene results into the column order produced by
+/// [`mask_results_schema`]. p-value columns are Float64; f32 truncated
+/// 5e-324 (the smallest f64 denormal that CCT and chisq survival use as a
+/// lower bound) to literal 0.0, masking the very underflows the floor
+/// exists to prevent.
+fn build_mask_columns(sorted: &[&GeneResult], n_channels: usize) -> Vec<ArrayRef> {
+    let nr = sorted.len();
+    let mut b_ensembl = StringBuilder::with_capacity(nr, nr * 16);
+    let mut b_symbol = StringBuilder::with_capacity(nr, nr * 12);
+    let mut b_chrom = StringBuilder::with_capacity(nr, nr * 2);
+    let mut b_start = UInt32Builder::with_capacity(nr);
+    let mut b_end = UInt32Builder::with_capacity(nr);
+    let mut b_nvariants = UInt32Builder::with_capacity(nr);
+    let mut b_cmac = UInt32Builder::with_capacity(nr);
+
+    let n_p_cols = 6 + 6 * n_channels + 6; // base + per-annotation + omnibus
+    let mut p_builders: Vec<Float64Builder> = (0..n_p_cols)
+        .map(|_| Float64Builder::with_capacity(nr))
+        .collect();
+    let mut b_acat_o = Float64Builder::with_capacity(nr);
+    let mut b_staar_o = Float64Builder::with_capacity(nr);
+
+    for r in sorted {
+        let s = &r.staar;
+        b_ensembl.append_value(&r.ensembl_id);
+        b_symbol.append_value(&r.gene_symbol);
+        b_chrom.append_value(r.chromosome.label());
+        b_start.append_value(r.start);
+        b_end.append_value(r.end);
+        b_nvariants.append_value(r.n_variants);
+        b_cmac.append_value(r.cumulative_mac);
+
+        let mut pi = 0;
+        for p in [
+            s.burden_1_25,
+            s.burden_1_1,
+            s.skat_1_25,
+            s.skat_1_1,
+            s.acat_v_1_25,
+            s.acat_v_1_1,
+        ] {
+            p_builders[pi].append_value(p);
+            pi += 1;
+        }
+        for ann_p in &s.per_annotation {
+            for &v in ann_p {
+                p_builders[pi].append_value(v);
+                pi += 1;
+            }
+        }
+        while pi < 6 + 6 * n_channels {
+            p_builders[pi].append_value(f64::NAN);
+            pi += 1;
+        }
+        for p in [
+            s.staar_b_1_25,
+            s.staar_b_1_1,
+            s.staar_s_1_25,
+            s.staar_s_1_1,
+            s.staar_a_1_25,
+            s.staar_a_1_1,
+        ] {
+            p_builders[pi].append_value(p);
+            pi += 1;
+        }
+        b_acat_o.append_value(s.acat_o);
+        b_staar_o.append_value(s.staar_o);
+    }
+
+    let mut columns: Vec<ArrayRef> = vec![
+        Arc::new(b_ensembl.finish()),
+        Arc::new(b_symbol.finish()),
+        Arc::new(b_chrom.finish()),
+        Arc::new(b_start.finish()),
+        Arc::new(b_end.finish()),
+        Arc::new(b_nvariants.finish()),
+        Arc::new(b_cmac.finish()),
+    ];
+    for b in &mut p_builders {
+        columns.push(Arc::new(b.finish()));
+    }
+    columns.push(Arc::new(b_acat_o.finish()));
+    columns.push(Arc::new(b_staar_o.finish()));
+    columns
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn write_results(
     all_mask_results: &[(MaskType, Vec<GeneResult>)],
@@ -158,6 +292,10 @@ pub fn write_results(
         .map(|c| c.weight_display_name().expect("STAAR_WEIGHTS entries have display names"))
         .collect();
     let n_channels = channels.len();
+
+    // Schema is identical for every mask file (same channels, same test set)
+    // — build it once before the loop instead of rebuilding it inside.
+    let schema = Arc::new(mask_results_schema(&channels));
 
     for (mask_type, results) in all_mask_results {
         if results.is_empty() {
@@ -181,134 +319,15 @@ pub fn write_results(
                 .unwrap_or(std::cmp::Ordering::Equal)
         });
 
-        let nr = sorted_results.len();
-        let mut b_ensembl = StringBuilder::with_capacity(nr, nr * 16);
-        let mut b_symbol = StringBuilder::with_capacity(nr, nr * 12);
-        let mut b_chrom = StringBuilder::with_capacity(nr, nr * 2);
-        let mut b_start = UInt32Builder::with_capacity(nr);
-        let mut b_end = UInt32Builder::with_capacity(nr);
-        let mut b_nvariants = UInt32Builder::with_capacity(nr);
-        let mut b_cmac = UInt32Builder::with_capacity(nr);
-
-        // All p-value columns are Float64. f32 truncated 5e-324 (the
-        // smallest f64 denormal, which CCT and chisq survival use as a
-        // lower bound) to literal 0.0, masking the very underflows the
-        // floor exists to prevent.
-        let n_p_cols = 6 + 6 * n_channels + 6; // base + annotation + omnibus
-        let mut p_builders: Vec<Float64Builder> = (0..n_p_cols)
-            .map(|_| Float64Builder::with_capacity(nr))
-            .collect();
-        let mut b_acat_o = Float64Builder::with_capacity(nr);
-        let mut b_staar_o = Float64Builder::with_capacity(nr);
-
-        for r in &sorted_results {
-            let s = &r.staar;
-            b_ensembl.append_value(&r.ensembl_id);
-            b_symbol.append_value(&r.gene_symbol);
-            b_chrom.append_value(r.chromosome.label());
-            b_start.append_value(r.start);
-            b_end.append_value(r.end);
-            b_nvariants.append_value(r.n_variants);
-            b_cmac.append_value(r.cumulative_mac);
-
-            let mut pi = 0;
-            for p in [
-                s.burden_1_25,
-                s.burden_1_1,
-                s.skat_1_25,
-                s.skat_1_1,
-                s.acat_v_1_25,
-                s.acat_v_1_1,
-            ] {
-                p_builders[pi].append_value(p);
-                pi += 1;
-            }
-            for ann_p in &s.per_annotation {
-                for &v in ann_p {
-                    p_builders[pi].append_value(v);
-                    pi += 1;
-                }
-            }
-            while pi < 6 + 6 * n_channels {
-                p_builders[pi].append_value(f64::NAN);
-                pi += 1;
-            }
-            for p in [
-                s.staar_b_1_25,
-                s.staar_b_1_1,
-                s.staar_s_1_25,
-                s.staar_s_1_1,
-                s.staar_a_1_25,
-                s.staar_a_1_1,
-            ] {
-                p_builders[pi].append_value(p);
-                pi += 1;
-            }
-            b_acat_o.append_value(s.acat_o);
-            b_staar_o.append_value(s.staar_o);
-        }
-
-        let test_names = [
-            "Burden(1,25)",
-            "Burden(1,1)",
-            "SKAT(1,25)",
-            "SKAT(1,1)",
-            "ACAT-V(1,25)",
-            "ACAT-V(1,1)",
-        ];
-        let mut fields = vec![
-            Field::new("ensembl_id", DataType::Utf8, false),
-            Field::new("gene_symbol", DataType::Utf8, false),
-            Field::new(Col::Chromosome.as_str(), DataType::Utf8, false),
-            Field::new("start", DataType::UInt32, false),
-            Field::new("end", DataType::UInt32, false),
-            Field::new("n_variants", DataType::UInt32, false),
-            Field::new("cMAC", DataType::UInt32, false),
-        ];
-        for test in &test_names {
-            fields.push(Field::new(*test, DataType::Float64, true));
-        }
-        for ch in &channels {
-            for test in &test_names {
-                fields.push(Field::new(format!("{test}-{ch}"), DataType::Float64, true));
-            }
-        }
-        for name in [
-            "STAAR-B(1,25)",
-            "STAAR-B(1,1)",
-            "STAAR-S(1,25)",
-            "STAAR-S(1,1)",
-            "STAAR-A(1,25)",
-            "STAAR-A(1,1)",
-        ] {
-            fields.push(Field::new(name, DataType::Float64, true));
-        }
-        fields.push(Field::new("ACAT-O", DataType::Float64, true));
-        fields.push(Field::new("STAAR-O", DataType::Float64, true));
-        let schema = Arc::new(Schema::new(fields));
-
-        let mut columns: Vec<ArrayRef> = vec![
-            Arc::new(b_ensembl.finish()),
-            Arc::new(b_symbol.finish()),
-            Arc::new(b_chrom.finish()),
-            Arc::new(b_start.finish()),
-            Arc::new(b_end.finish()),
-            Arc::new(b_nvariants.finish()),
-            Arc::new(b_cmac.finish()),
-        ];
-        for b in &mut p_builders {
-            columns.push(Arc::new(b.finish()));
-        }
-        columns.push(Arc::new(b_acat_o.finish()));
-        columns.push(Arc::new(b_staar_o.finish()));
-
+        let columns = build_mask_columns(&sorted_results, n_channels);
         let batch = RecordBatch::try_new(schema.clone(), columns)
             .map_err(|e| CohortError::Resource(format!("Arrow batch: {e}")))?;
+        let schema_for_write = schema.clone();
         write_parquet_atomic(&out_path, |file| {
             let props = WriterProperties::builder()
                 .set_compression(Compression::ZSTD(Default::default()))
                 .build();
-            let mut writer = ArrowWriter::try_new(file, schema, Some(props))
+            let mut writer = ArrowWriter::try_new(file, schema_for_write, Some(props))
                 .map_err(|e| CohortError::Resource(format!("Parquet writer: {e}")))?;
             writer
                 .write(&batch)
@@ -396,7 +415,7 @@ const SIGNIFICANCE: f64 = 2.5e-6;
 
 struct PlotGene {
     gene: String,
-    mask: String,
+    mask: &'static str,
     chromosome: String,
     genome_x: f64,
     neg_log_p: f64,
@@ -418,20 +437,16 @@ pub fn generate_report(
     title: &str,
 ) -> Result<(), CohortError> {
     let genes = collect_plot_genes(results);
-    let pvals = collect_pvalues(results);
     let n_genes: usize = results.iter().map(|(_, r)| r.len()).sum();
     let n_sig = genes.iter().filter(|g| g.staar_o < SIGNIFICANCE).count();
-    let masks: Vec<String> = results
+    let masks: Vec<&'static str> = results
         .iter()
         .filter(|(_, r)| !r.is_empty())
         .map(|(m, _)| m.file_stem())
         .collect();
 
-    // Manhattan data: JSON arrays
     let manhattan_json = manhattan_traces(&genes);
-    // QQ data
-    let qq_json = qq_trace(&pvals);
-    // Volcano data
+    let qq_json = qq_traces_per_mask(results);
     let volcano_json = volcano_trace(&genes);
     // Table rows
     let table_rows = table_json(&genes);
@@ -621,15 +636,6 @@ fn chrom_offsets() -> HashMap<String, (usize, u64)> {
     map
 }
 
-fn collect_pvalues(results: &[(MaskType, Vec<GeneResult>)]) -> Vec<f64> {
-    results
-        .iter()
-        .flat_map(|(_, genes)| genes.iter().map(|g| g.staar.staar_o))
-        .filter(|p| p.is_finite() && *p <= 1.0)
-        .map(|p| if p <= 0.0 { 1e-300 } else { p })
-        .collect()
-}
-
 fn manhattan_traces(genes: &[PlotGene]) -> String {
     // Group by chromosome for alternating colors
     let colors = ["#4361ee", "#7f8fa6"];
@@ -716,52 +722,84 @@ fn manhattan_traces(genes: &[PlotGene]) -> String {
     )
 }
 
-fn qq_trace(pvalues: &[f64]) -> String {
-    let mut valid: Vec<f64> = pvalues
+/// Sorted, finite, non-zero p-values for one mask.
+fn collect_mask_pvalues(genes: &[GeneResult]) -> Vec<f64> {
+    let mut v: Vec<f64> = genes
         .iter()
-        .filter(|p| p.is_finite() && **p > 0.0 && **p <= 1.0)
-        .copied()
+        .map(|g| g.staar.staar_o)
+        .filter(|p| p.is_finite() && *p > 0.0 && *p <= 1.0)
         .collect();
-    valid.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    v.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    v
+}
 
-    if valid.is_empty() {
+/// Build one QQ trace per mask plus a single y=x diagonal. Subsampling
+/// preserves the tail (top 100 points) so genome-wide-significant deviations
+/// stay visible even on dense plots.
+fn qq_traces_per_mask(results: &[(MaskType, Vec<GeneResult>)]) -> String {
+    // Distinct hues for up to 17 masks (the full STAAR catalog has 17).
+    const PALETTE: &[&str] = &[
+        "#4361ee", "#c62828", "#2e7d32", "#ef6c00", "#6a1b9a", "#00838f", "#827717", "#ad1457",
+        "#1565c0", "#558b2f", "#d84315", "#283593", "#00695c", "#4e342e", "#37474f", "#bf360c",
+        "#9e9d24",
+    ];
+
+    let mut traces: Vec<String> = Vec::new();
+    let mut axis_max: f64 = 1.0;
+
+    for (color_idx, (mask, genes)) in results.iter().filter(|(_, g)| !g.is_empty()).enumerate() {
+        let valid = collect_mask_pvalues(genes);
+        if valid.is_empty() {
+            continue;
+        }
+        let n = valid.len();
+        let observed: Vec<f64> = valid.iter().map(|p| -p.log10()).collect();
+        let expected: Vec<f64> = (0..n)
+            .map(|i| -((i as f64 + 0.5) / n as f64).log10())
+            .collect();
+
+        if let Some(&o) = observed.last() {
+            axis_max = axis_max.max(o);
+        }
+        if let Some(&e) = expected.last() {
+            axis_max = axis_max.max(e);
+        }
+
+        let step = if n > 3000 { n / 3000 } else { 1 };
+        let mut exp_s = Vec::with_capacity(n / step + 100);
+        let mut obs_s = Vec::with_capacity(n / step + 100);
+        for i in (0..n).step_by(step) {
+            exp_s.push(format!("{:.4}", expected[i]));
+            obs_s.push(format!("{:.4}", observed[i]));
+        }
+        for i in n.saturating_sub(100)..n {
+            exp_s.push(format!("{:.4}", expected[i]));
+            obs_s.push(format!("{:.4}", observed[i]));
+        }
+
+        let color = PALETTE[color_idx % PALETTE.len()];
+        traces.push(format!(
+            "{{x:[{exp}],y:[{obs}],mode:'markers',type:'scatter',\
+             name:'{name}',marker:{{color:'{color}',size:3,opacity:0.65}},\
+             hoverinfo:'x+y+name'}}",
+            exp = exp_s.join(","),
+            obs = obs_s.join(","),
+            name = mask.file_stem(),
+            color = color,
+        ));
+    }
+
+    if traces.is_empty() {
         return "var traces=[];".into();
     }
 
-    let n = valid.len();
-    let observed: Vec<f64> = valid.iter().map(|p| -p.log10()).collect();
-    let expected: Vec<f64> = (0..n)
-        .map(|i| -((i as f64 + 0.5) / n as f64).log10())
-        .collect();
-    let axis_max = observed
-        .last()
-        .copied()
-        .unwrap_or(1.0)
-        .max(*expected.last().unwrap_or(&1.0))
-        + 0.5;
+    let ax = axis_max + 0.5;
+    traces.push(format!(
+        "{{x:[0,{ax:.1}],y:[0,{ax:.1}],mode:'lines',line:{{color:'#ccc',dash:'dash'}},showlegend:false}}",
+        ax = ax,
+    ));
 
-    // Subsample for performance, keep tail
-    let step = if n > 3000 { n / 3000 } else { 1 };
-    let mut exp_s = Vec::new();
-    let mut obs_s = Vec::new();
-    for i in (0..n).step_by(step) {
-        exp_s.push(format!("{:.4}", expected[i]));
-        obs_s.push(format!("{:.4}", observed[i]));
-    }
-    // Always include tail
-    for i in n.saturating_sub(100)..n {
-        exp_s.push(format!("{:.4}", expected[i]));
-        obs_s.push(format!("{:.4}", observed[i]));
-    }
-
-    format!(
-        "var traces=[{{x:[{exp}],y:[{obs}],mode:'markers',type:'scatter',\
-         marker:{{color:'#4361ee',size:3,opacity:0.5}},hoverinfo:'x+y',showlegend:false}},\
-         {{x:[0,{ax:.1}],y:[0,{ax:.1}],mode:'lines',line:{{color:'#ccc',dash:'dash'}},showlegend:false}}];",
-        exp = exp_s.join(","),
-        obs = obs_s.join(","),
-        ax = axis_max,
-    )
+    format!("var traces=[{}];", traces.join(","))
 }
 
 fn volcano_trace(genes: &[PlotGene]) -> String {
@@ -902,6 +940,8 @@ mod tests {
                 acat_o: p,
                 staar_o: p,
             },
+            burden_beta: f64::NAN,
+            burden_se: f64::NAN,
         }
     }
 

--- a/src/staar/scoring.rs
+++ b/src/staar/scoring.rs
@@ -58,15 +58,9 @@ impl MaskPlan {
 
         for cat in categories {
             match cat {
-                MaskCategory::Coding => {
-                    for &(ref mt, pred) in masks::CODING_MASKS {
-                        gene_predicates.push((mt.clone(), pred));
-                    }
-                }
+                MaskCategory::Coding => gene_predicates.extend_from_slice(masks::CODING_MASKS),
                 MaskCategory::Noncoding => {
-                    for &(ref mt, pred) in masks::NONCODING_MASKS {
-                        gene_predicates.push((mt.clone(), pred));
-                    }
+                    gene_predicates.extend_from_slice(masks::NONCODING_MASKS)
                 }
                 MaskCategory::SlidingWindow => want_windows = true,
                 MaskCategory::Scang => want_scang = true,
@@ -76,7 +70,7 @@ impl MaskPlan {
 
         let mut results: ResultSet = gene_predicates
             .iter()
-            .map(|(mt, _)| (mt.clone(), Vec::new()))
+            .map(|(mt, _)| (*mt, Vec::new()))
             .collect();
 
         let window_slot = want_windows.then(|| {
@@ -401,6 +395,8 @@ fn score_gene_masks(
                 n_variants: qualifying.len() as u32,
                 cumulative_mac: cmac,
                 staar,
+                burden_beta: f64::NAN,
+                burden_se: f64::NAN,
             },
         ));
     }
@@ -602,6 +598,8 @@ fn score_one_window(
         n_variants: m as u32,
         cumulative_mac: cmac,
         staar,
+        burden_beta: f64::NAN,
+        burden_se: f64::NAN,
     })
 }
 

--- a/src/staar/stats.rs
+++ b/src/staar/stats.rs
@@ -97,16 +97,14 @@ pub fn mixture_chisq_pvalue(statistic: f64, eigenvalues: &[f64]) -> f64 {
         return f64::NAN;
     }
 
-    // Match SKAT R: Get_Lambda_Org — keep eigenvalues > mean(positive) / 100000
-    let positive: Vec<f64> = eigenvalues.iter().copied().filter(|&l| l >= 0.0).collect();
-    if positive.is_empty() {
-        return 1.0;
-    }
-    let threshold = positive.iter().sum::<f64>() / positive.len() as f64 / 100000.0;
+    // Match upstream STAAR_O.cpp / MetaSTAAR_O_SMMAT.cpp: drop eigenvalues
+    // below 1e-8. SKAT-R's `Get_Lambda_Org` uses mean(positive)/100000, but
+    // we are tracking the STAAR C++ convention so the omnibus matches.
+    const LAMBDA_FLOOR: f64 = 1e-8;
     let lambdas: Vec<f64> = eigenvalues
         .iter()
         .copied()
-        .filter(|&l| l > threshold)
+        .filter(|&l| l > LAMBDA_FLOOR)
         .collect();
     if lambdas.is_empty() {
         return 1.0;


### PR DESCRIPTION
MetaSTAAR: canonicalize ref/alt as lex-min and sign-flip u_stat per study on flip; off-diagonal of K is sign-corrected on lookup. K=1 study now allowed. Burden β = 1ᵀU/1ᵀK1 and SE = √(1/1ᵀK1) on every meta gene result, written as two new parquet columns. SKAT eigenvalue truncation moved to hard 1e-8 to match STAAR_O.cpp.

MultiSTAAR: replaced the per-trait Cauchy scaffold with the real joint score test for unrelated continuous traits. P and the joint covariance Kronecker-factor as Σ_res⁻¹ ⊗ M and Σ_res⁻¹ ⊗ K₀, so neither is materialized. Per-variant joint χ²(k), joint burden, joint SKAT via Kronecker eigenvalue product. k=1 reduces to single-trait STAAR exactly. Not yet wired into the pipeline.

Per-mask QQ: one trace per mask in the summary report, single shared diagonal.

Dry-run: optional RuntimeEstimate on DryRunPlan; staar and meta-staar emit budgets, the rest set None.

Closes #7 #8 #9 #10 #22 #30. Verified moot #29. Partial #6 (algorithm landed, wiring pending).

249 tests passing.