### PR TITLE
v0.2.0: multi-VCF, single-pass ingest, null model cache, enrichment pruning, conditional MetaSTAAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
 
 ---
 
+> **Pre-1.0 software.** Interfaces, resource profiles, and on-disk layouts may change between releases.
+
 ## Install
 
 ```bash
@@ -100,10 +102,29 @@ The store root is resolved as: `--store-path` flag > `FAVOR_STORE` env > walk up
 
 See [Setup guide](docs/setup.md) for detailed configuration, pack selection, HPC tips, and working directory organization.
 
+## Resource requirements
+
+Tested on UKB exome chr22 (~200K samples, ~400K variants, ~17K rare) with 64 GB. Full genome not yet tested. Memory scales with sample count, not variant count.
+
+```text
+samples    RAM       notes
+───────    ──────    ─────────────────────────────
+ 10K       32 GB     comfortable
+200K       64 GB     tested (UKB exome chr22)
+```
+
+Memory, threads, and temp directory are auto-detected from SLURM and cgroup. Override with:
+
+```text
+SLURM_MEM_PER_NODE     memory pool
+FAVOR_KINSHIP_MEM_GB   kinship budget (default 16 GB)
+TMPDIR                 scratch space
+```
+
 ## Docs
 
 - **[Setup guide](docs/setup.md)** - installation, configuration, data management, HPC best practices
-- [Genotype store](docs/storage.md) - on-disk format for cohort genotype data
+- [Genotype store](docs/storage.md) - sparse genotype store for rare-variant analysis
 - [Validation](docs/validation.md) - statistical accuracy vs R reference
 - [Performance](docs/performance.md) - benchmarks and optimization roadmap
 - [Agent reference](AGENTS.md) - machine interface for LLM agents

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,6 +4,12 @@ use clap::{Parser, Subcommand, ValueEnum};
 
 use crate::output::Format;
 
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum ConditionalModel {
+    Homogeneous,
+    Heterogeneous,
+}
+
 #[derive(Debug, Clone, ValueEnum)]
 pub enum GenomeBuild {
     Hg38,
@@ -315,6 +321,15 @@ pub enum Command {
         /// Sliding window size in bp [default: 2000]
         #[arg(long, default_value = "2000")]
         window_size: u32,
+
+        /// Known loci for conditional analysis (one chr:pos:ref:alt per line)
+        #[arg(long)]
+        known_loci: Option<PathBuf>,
+
+        /// Conditional model: homogeneous (shared effects across studies) or
+        /// heterogeneous (study-specific effects)
+        #[arg(long, default_value = "homogeneous")]
+        conditional_model: ConditionalModel,
 
         /// Output directory
         #[arg(short, long)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -181,10 +181,12 @@ pub enum Command {
 
     /// STAAR rare variant association testing
     Staar {
-        /// Multi-sample VCF with genotypes (.vcf or .vcf.gz). Required unless
-        /// `--cohort <id>` is given to load a pre-built cohort store.
-        #[arg(long)]
-        genotypes: Option<PathBuf>,
+        /// Multi-sample VCF(s) with genotypes (.vcf or .vcf.gz). Accepts
+        /// multiple files, globs, or a directory of per-chromosome VCFs.
+        /// Required unless `--cohort <id>` is given to load a pre-built
+        /// cohort store.
+        #[arg(long, num_args = 1..)]
+        genotypes: Vec<PathBuf>,
 
         /// Pre-built cohort id (from `favor ingest <vcf> --annotations ... --cohort-id <id>`).
         /// Skips probe + rebuild — trusts the manifest at `.cohort/cohorts/<id>/`.

--- a/src/commands/enrich.rs
+++ b/src/commands/enrich.rs
@@ -208,15 +208,27 @@ fn run_enrichment(
 
     engine.execute("CREATE TABLE _input_vids AS SELECT DISTINCT vid FROM _input")?;
 
+    // Chromosome pruning: only scan tissue chromosomes that have query variants.
+    let query_chroms = annotated.chromosomes();
+    let query_chrom_set: std::collections::HashSet<&str> =
+        query_chroms.iter().copied().collect();
+
     let mut tables_written: Vec<(String, i64)> = Vec::new();
 
     for &table in tissue_db.available_tables() {
         let table_path = tissue_db.table_path(table);
         let table_name = format!("_enrich_{}", table.display_name());
-        if engine
-            .register_parquet_dir(&table_name, &table_path)
-            .is_err()
-        {
+
+        // Register only chromosome subdirectories that overlap with query
+        // variants instead of the full directory.
+        let registered = register_pruned_tissue(
+            engine,
+            &table_path,
+            &table_name,
+            &query_chrom_set,
+            out,
+        )?;
+        if !registered {
             continue;
         }
 
@@ -265,5 +277,66 @@ fn run_enrichment(
     }
 
     Ok(tables_written)
+}
+
+/// Register only the chromosome subdirectories of a tissue table that overlap
+/// with the query variant set. Returns false if no matching chromosomes found.
+fn register_pruned_tissue(
+    engine: &DfEngine,
+    table_path: &std::path::Path,
+    table_name: &str,
+    query_chroms: &std::collections::HashSet<&str>,
+    out: &dyn Output,
+) -> Result<bool, CohortError> {
+    // Discover available chromosome directories in the tissue table.
+    let entries = match std::fs::read_dir(table_path) {
+        Ok(e) => e,
+        Err(_) => return Ok(false),
+    };
+
+    let mut parts: Vec<(String, std::path::PathBuf)> = Vec::new();
+    let mut skipped = 0usize;
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if let Some(chrom) = name.strip_prefix("chromosome=") {
+            if query_chroms.contains(chrom) {
+                let parquet = entry.path().join("sorted.parquet");
+                if parquet.exists() {
+                    parts.push((chrom.to_string(), parquet));
+                }
+            } else {
+                skipped += 1;
+            }
+        }
+    }
+
+    if parts.is_empty() {
+        return Ok(false);
+    }
+
+    if skipped > 0 {
+        out.status(&format!(
+            "  {}: scanning {} chromosome(s) (skipped {skipped})",
+            table_name.strip_prefix("_enrich_").unwrap_or(table_name),
+            parts.len()
+        ));
+    }
+
+    if parts.len() == 1 {
+        engine.register_parquet_file(table_name, &parts[0].1)?;
+    } else {
+        for (i, (_, path)) in parts.iter().enumerate() {
+            engine.register_parquet_file(&format!("{table_name}_p{i}"), path)?;
+        }
+        let union_parts: Vec<String> = (0..parts.len())
+            .map(|i| format!("SELECT * FROM {table_name}_p{i}"))
+            .collect();
+        engine.execute(&format!(
+            "CREATE VIEW {table_name} AS {}",
+            union_parts.join(" UNION ALL "),
+        ))?;
+    }
+
+    Ok(true)
 }
 

--- a/src/commands/ingest.rs
+++ b/src/commands/ingest.rs
@@ -14,7 +14,7 @@ use crate::staar::genotype::read_sample_names;
 use crate::store::cohort::{BuildOpts, CohortId, CohortSources, ProbeReason, StoreProbe};
 use crate::store::list::{VariantSet, VariantSetKind, VariantSetWriter};
 
-fn resolve_inputs(raw: Vec<PathBuf>) -> Result<Vec<PathBuf>, CohortError> {
+pub(crate) fn resolve_inputs(raw: Vec<PathBuf>) -> Result<Vec<PathBuf>, CohortError> {
     let mut resolved = Vec::new();
     for p in raw {
         if !p.exists() {
@@ -120,13 +120,16 @@ pub fn run_ingest(
     }
 
     if analysis.format == InputFormat::Vcf {
-        if config.inputs.len() == 1 {
+        // Multi-sample VCF with --annotations: build cohort store.
+        if config.annotations.is_some() {
             let n_samples = read_sample_names(first)?.len();
             if n_samples > 0 {
                 return run_cohort_build(engine, config, n_samples, out);
             }
         }
-        return ingest_vcf(engine, config, out);
+        // Check if VCF has samples for single-pass dual-write.
+        let n_samples = read_sample_names(first)?.len();
+        return ingest_vcf(engine, config, n_samples, out);
     }
     if config.emit_sql || analysis.needs_intervention() {
         return emit_sql_script(config, &analysis, out);
@@ -181,7 +184,7 @@ fn run_cohort_build(
             miss_reason: Some(ProbeReason::NoManifest),
         }
     } else {
-        cohort.probe(vcf_path, annotations_path)
+        cohort.probe(&config.inputs, annotations_path)
     };
 
     let staging_dir = {
@@ -212,7 +215,7 @@ fn run_cohort_build(
 
     let result = cohort.build_or_load(
         CohortSources {
-            genotypes: vcf_path,
+            genotypes: &config.inputs,
             annotations: annotations_path,
         },
         BuildOpts {
@@ -297,6 +300,7 @@ fn validate_all_same_format(
 fn ingest_vcf(
     engine: &Engine,
     config: &IngestConfig,
+    n_samples: usize,
     out: &dyn Output,
 ) -> Result<(), CohortError> {
     let first = &config.inputs[0];
@@ -313,12 +317,24 @@ fn ingest_vcf(
     }
 
     let resources = engine.resources();
-    out.status(&format!(
-        "Ingesting {} VCF file(s) ({}, {} threads)",
-        config.inputs.len(),
-        resources.memory_human(),
-        resources.threads
-    ));
+    let dual_write = n_samples > 0;
+
+    if dual_write {
+        out.status(&format!(
+            "Ingesting {} VCF file(s) + extracting genotypes ({} samples, {}, {} threads)",
+            config.inputs.len(),
+            n_samples,
+            resources.memory_human(),
+            resources.threads
+        ));
+    } else {
+        out.status(&format!(
+            "Ingesting {} VCF file(s) ({}, {} threads)",
+            config.inputs.len(),
+            resources.memory_human(),
+            resources.threads
+        ));
+    }
 
     let source_str = if config.inputs.len() == 1 {
         first.display().to_string()
@@ -329,16 +345,41 @@ fn ingest_vcf(
         VariantSetWriter::new(&config.output, ingest::JoinKey::ChromPosRefAlt, &source_str)?;
     vs_writer.set_kind(VariantSetKind::Ingested);
 
+    let geno_dir = config.output.with_extension("genotypes");
+    let mut geno_writer = if dual_write {
+        Some(crate::staar::genotype::GenotypeWriter::new(
+            n_samples,
+            &geno_dir,
+            resources.memory_bytes / 2,
+        )?)
+    } else {
+        None
+    };
+
     bail_if_cancelled(out)?;
     let result = ingest::vcf::ingest_vcfs(
         &config.inputs,
         &mut vs_writer,
+        geno_writer.as_mut(),
         resources.memory_bytes,
         resources.threads,
         out,
     )?;
     bail_if_cancelled(out)?;
     let vs = vs_writer.finish()?;
+
+    // Finalize genotype writer if active.
+    if let Some(gw) = geno_writer {
+        let sample_names = read_sample_names(first)?;
+        let source_vcfs = config.inputs.iter().map(|p| p.display().to_string()).collect();
+        let geno_result = gw.finish(&sample_names, source_vcfs)?;
+        out.success(&format!(
+            "  Genotypes: {} variants × {} samples -> {}",
+            result.genotype_variants,
+            n_samples,
+            geno_result.output_dir.display()
+        ));
+    }
 
     out.success(&format!(
         "Ingested {} variants from {} file(s) -> {}",
@@ -359,13 +400,19 @@ fn ingest_vcf(
         ));
     }
 
-    out.result_json(&json!({
+    let mut result_json = json!({
         "status": "ok",
         "output": vs.root().to_string_lossy(),
         "variant_count": result.variant_count,
         "file_count": config.inputs.len(),
         "join_key": "chrom_pos_ref_alt",
-    }));
+    });
+    if dual_write {
+        result_json["genotype_dir"] = json!(geno_dir.to_string_lossy());
+        result_json["genotype_variants"] = json!(result.genotype_variants);
+        result_json["n_samples"] = json!(n_samples);
+    }
+    out.result_json(&result_json);
 
     Ok(())
 }

--- a/src/commands/meta_staar.rs
+++ b/src/commands/meta_staar.rs
@@ -26,12 +26,23 @@ pub fn build_config(
     masks: Vec<String>,
     maf_cutoff: f64,
     window_size: u32,
+    known_loci: Option<PathBuf>,
+    conditional_model: crate::cli::ConditionalModel,
     output_path: Option<PathBuf>,
 ) -> Result<MetaStaarConfig, CohortError> {
     if studies.is_empty() {
         return Err(CohortError::Input(
             "--studies is required. Provide comma-separated paths to MetaSTAAR summary stat directories.".into(),
         ));
+    }
+
+    if let Some(ref loci) = known_loci {
+        if !loci.exists() {
+            return Err(CohortError::Input(format!(
+                "Known loci file not found: {}",
+                loci.display()
+            )));
+        }
     }
 
     let mask_categories = crate::commands::parse_mask_categories(&masks)?;
@@ -42,6 +53,8 @@ pub fn build_config(
         mask_categories,
         maf_cutoff,
         window_size,
+        known_loci,
+        conditional_model,
         output_dir,
     })
 }
@@ -85,7 +98,16 @@ pub fn run_meta_staar(
         ))
     })?;
 
-    let results = run_all_chromosomes(&studies, config, df, out)?;
+    let known_loci = match config.known_loci.as_ref() {
+        Some(path) => {
+            let loci = staar::meta::parse_known_loci_file(path)?;
+            out.status(&format!("  Conditional: {} known loci loaded", loci.len()));
+            loci
+        }
+        None => Vec::new(),
+    };
+
+    let results = run_all_chromosomes(&studies, config, &known_loci, df, out)?;
     write_meta_results(&results, &config.output_dir, out)?;
     generate_summary(&studies, &results, config, out);
 
@@ -138,10 +160,16 @@ fn meta_staar_runtime_seconds(n_studies: usize, total_samples: usize, threads: u
 fn run_all_chromosomes(
     studies: &[staar::meta::StudyHandle],
     config: &MetaStaarConfig,
+    known_loci: &[(String, u32, String, String)],
     engine: &DfEngine,
     out: &dyn Output,
 ) -> Result<Vec<(MaskType, Vec<GeneResult>)>, CohortError> {
     let k = studies.len();
+    let conditional = !known_loci.is_empty();
+    let heterogeneous = matches!(
+        config.conditional_model,
+        crate::cli::ConditionalModel::Heterogeneous
+    );
     let chromosomes = discover_chromosomes(&studies[0].path);
     let mut all_results: Vec<(MaskType, Vec<GeneResult>)> = Vec::new();
 
@@ -158,6 +186,19 @@ fn run_all_chromosomes(
         }
         out.status(&format!("    {} merged variants", meta_variants.len()));
 
+        // Find known-loci indices for this chromosome.
+        let cond_indices: Vec<usize> = if conditional {
+            find_known_loci_indices(&meta_variants, known_loci, chrom)
+        } else {
+            Vec::new()
+        };
+        if conditional && !cond_indices.is_empty() {
+            out.status(&format!(
+                "    conditional: {} known loci matched on chr{chrom}",
+                cond_indices.len()
+            ));
+        }
+
         let annotated: Vec<crate::types::AnnotatedVariant> =
             meta_variants.iter().map(|mv| mv.variant.clone()).collect();
         let chrom_indices: Vec<usize> = (0..annotated.len()).collect();
@@ -170,12 +211,23 @@ fn run_all_chromosomes(
             let results: Vec<GeneResult> = groups
                 .par_iter()
                 .filter_map(|group| {
-                    staar::meta::meta_score_gene(
-                        group,
-                        &meta_variants,
-                        studies,
-                        &segment_cache,
-                    )
+                    if cond_indices.is_empty() {
+                        staar::meta::meta_score_gene(
+                            group,
+                            &meta_variants,
+                            studies,
+                            &segment_cache,
+                        )
+                    } else {
+                        staar::meta::meta_score_gene_conditional(
+                            group,
+                            &meta_variants,
+                            studies,
+                            &segment_cache,
+                            &cond_indices,
+                            heterogeneous,
+                        )
+                    }
                 })
                 .collect();
 
@@ -251,6 +303,38 @@ fn load_segment_cache(
         }
     }
     cache
+}
+
+/// Find indices in `meta_variants` that correspond to known loci on this chromosome.
+fn find_known_loci_indices(
+    meta_variants: &[crate::types::MetaVariant],
+    known_loci: &[(String, u32, String, String)],
+    chrom: &str,
+) -> Vec<usize> {
+    let chrom_loci: Vec<&(String, u32, String, String)> = known_loci
+        .iter()
+        .filter(|(c, _, _, _)| c == chrom)
+        .collect();
+    if chrom_loci.is_empty() {
+        return Vec::new();
+    }
+
+    let mut indices = Vec::new();
+    for (i, mv) in meta_variants.iter().enumerate() {
+        for locus in &chrom_loci {
+            if mv.variant.position == locus.1 {
+                // Wildcard ref/alt match (chr:pos only) or exact match.
+                if locus.2 == "*"
+                    || (&*mv.variant.ref_allele == locus.2.as_str()
+                        && &*mv.variant.alt_allele == locus.3.as_str())
+                {
+                    indices.push(i);
+                    break;
+                }
+            }
+        }
+    }
+    indices
 }
 
 fn discover_chromosomes(study_dir: &std::path::Path) -> Vec<String> {

--- a/src/commands/meta_staar.rs
+++ b/src/commands/meta_staar.rs
@@ -43,6 +43,14 @@ pub fn build_config(
                 loci.display()
             )));
         }
+        if matches!(conditional_model, crate::cli::ConditionalModel::Heterogeneous) {
+            return Err(CohortError::Input(
+                "--conditional-model heterogeneous requires per-study U vectors \
+                 which --emit-sumstats does not yet persist. Use --conditional-model \
+                 homogeneous for now."
+                    .into(),
+            ));
+        }
     }
 
     let mask_categories = crate::commands::parse_mask_categories(&masks)?;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -89,6 +89,8 @@ pub struct MetaStaarConfig {
     pub mask_categories: Vec<MaskCategory>,
     pub maf_cutoff: f64,
     pub window_size: u32,
+    pub known_loci: Option<PathBuf>,
+    pub conditional_model: crate::cli::ConditionalModel,
     pub output_dir: PathBuf,
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -157,10 +157,6 @@ pub fn emit(plan: &DryRunPlan, out: &dyn Output) {
     out.result_json(&serde_json::to_value(plan).unwrap_or_default());
 }
 
-pub fn file_size(path: &Path) -> u64 {
-    std::fs::metadata(path).map(|m| m.len()).unwrap_or(0)
-}
-
 /// Default output path for a command that transforms an input file in
 /// place: strip any of `strip_suffixes` from the file name (first match
 /// wins), then append `append` and rejoin to the parent directory.

--- a/src/commands/staar.rs
+++ b/src/commands/staar.rs
@@ -18,7 +18,7 @@ use crate::store::list::VariantSet;
 const GB: u64 = 1024 * 1024 * 1024;
 
 pub struct StaarArgs {
-    pub genotypes: Option<PathBuf>,
+    pub genotypes: Vec<PathBuf>,
     pub cohort: Option<String>,
     pub phenotype: PathBuf,
     pub trait_names: Vec<String>,
@@ -127,7 +127,7 @@ fn build_config(args: StaarArgs) -> Result<StaarConfig, CohortError> {
     let cohort_name = blank_to_none(args.cohort.clone());
     let (cohort_source, cohort_id, output_dir) = match cohort_name {
         Some(id) => {
-            if args.genotypes.is_some() {
+            if !args.genotypes.is_empty() {
                 return Err(CohortError::Input(
                     "Pass either --cohort <id> (load pre-built) or --genotypes <vcf> \
                      (probe/build), not both."
@@ -142,18 +142,13 @@ fn build_config(args: StaarArgs) -> Result<StaarConfig, CohortError> {
             (CohortSource::Existing, cohort_id, output_dir)
         }
         None => {
-            let genotypes = args.genotypes.clone().ok_or_else(|| {
-                CohortError::Input(
+            if args.genotypes.is_empty() {
+                return Err(CohortError::Input(
                     "STAAR needs either --cohort <id> (pre-built cohort) or --genotypes <vcf>."
                         .into(),
-                )
-            })?;
-            if !genotypes.exists() {
-                return Err(CohortError::Input(format!(
-                    "Genotype VCF not found: '{}'. Check the path to your multi-sample VCF.",
-                    genotypes.display()
-                )));
+                ));
             }
+            let genotypes = crate::commands::ingest::resolve_inputs(args.genotypes)?;
             let annotations = args.annotations.clone().ok_or_else(|| {
                 CohortError::Input(
                     "Without --cohort, STAAR requires --annotations <path> from \
@@ -177,12 +172,12 @@ fn build_config(args: StaarArgs) -> Result<StaarConfig, CohortError> {
             ann_vs.require_annotated()?;
             let cohort_id = CohortId::new(
                 blank_to_none(args.cohort_id.clone())
-                    .unwrap_or_else(|| derive_cohort_id(&genotypes)),
+                    .unwrap_or_else(|| derive_cohort_id(&genotypes[0])),
             );
             let output_dir = args
                 .output_path
                 .clone()
-                .unwrap_or_else(|| default_output_dir(&genotypes));
+                .unwrap_or_else(|| default_output_dir(&genotypes[0]));
             (
                 CohortSource::Fresh {
                     genotypes,
@@ -340,7 +335,7 @@ fn emit_dry_run(
                 )
             }
             (Some(genotypes), Some(annotations)) => {
-                let sample_names = staar::genotype::read_sample_names(genotypes)?;
+                let sample_names = staar::genotype::read_sample_names(&genotypes[0])?;
                 let n_samples = sample_names.len();
                 let ann_rows = parquet_row_count(annotations).unwrap_or_else(|e| {
                     out.warn(&format!(
@@ -368,9 +363,12 @@ fn emit_dry_run(
                     ),
                     None => ("miss", json!(null), recommended.max(8 * GB)),
                 };
+                let geno_files: Vec<String> = genotypes.iter()
+                    .map(|p| p.to_string_lossy().into())
+                    .collect();
                 let inputs = json!({
-                    "genotypes": genotypes.to_string_lossy(),
-                    "genotype_size": commands::file_size(genotypes),
+                    "genotypes": geno_files,
+                    "genotype_file_count": genotypes.len(),
                     "annotations": annotations.to_string_lossy(),
                     "annotation_rows": ann_rows,
                     "n_samples": n_samples,
@@ -544,7 +542,7 @@ mod tests {
     /// runs before the cohort branch, which is what we want to exercise.
     fn multi_trait_args(pheno_path: PathBuf, traits: &[&str]) -> StaarArgs {
         StaarArgs {
-            genotypes: None,
+            genotypes: Vec::new(),
             cohort: Some("dummy".into()),
             phenotype: pheno_path,
             trait_names: traits.iter().map(|s| (*s).into()).collect(),

--- a/src/ingest/vcf.rs
+++ b/src/ingest/vcf.rs
@@ -19,6 +19,7 @@ use parquet::arrow::ArrowWriter;
 use parquet::basic::Compression;
 use parquet::file::properties::WriterProperties;
 
+use crate::staar::genotype::GenotypeWriter;
 use crate::store::list::VariantSetWriter;
 use crate::error::CohortError;
 use crate::output::Output;
@@ -271,6 +272,8 @@ pub struct VcfIngestResult {
     pub variant_count: u64,
     pub filtered_contigs: u64,
     pub multiallelic_split: u64,
+    /// When single-pass ingest is active, the number of genotype variants written.
+    pub genotype_variants: u64,
 }
 
 /// Per-chromosome writer state: batch + parquet writer + variant count.
@@ -284,9 +287,13 @@ struct ChromWriter {
 /// All files share the same set of per-chromosome writers, so blocks from
 /// different files (e.g., UKB b0-b22) merge into the correct chromosome output.
 /// Bounded memory: 25 chromosome writers max, each with adaptive batch size.
+///
+/// When `geno_writer` is `Some`, genotype dosages are extracted in the same
+/// pass and written to the GenotypeWriter (single-pass ingest).
 pub fn ingest_vcfs(
     input_paths: &[PathBuf],
     vs_writer: &mut VariantSetWriter,
+    geno_writer: Option<&mut GenotypeWriter>,
     memory_budget: u64,
     threads: usize,
     output: &dyn Output,
@@ -308,6 +315,7 @@ pub fn ingest_vcfs(
     let mut variant_count: u64 = 0;
     let mut filtered_contigs: u64 = 0;
     let mut multiallelic_split: u64 = 0;
+    let mut gw = geno_writer;
 
     for (file_idx, input_path) in input_paths.iter().enumerate() {
         if input_paths.len() > 1 {
@@ -350,6 +358,7 @@ pub fn ingest_vcfs(
                 &record,
                 &mut writers,
                 vs_writer,
+                gw.as_deref_mut(),
                 &schema,
                 &props,
                 batch_size,
@@ -362,6 +371,8 @@ pub fn ingest_vcfs(
         }
         pb.finish(&format!("{variant_count} variants ingested"));
     }
+
+    let genotype_variants = gw.as_ref().map_or(0, |g| g.variant_count());
 
     // Flush and close all writers
     vs_writer.set_columns(schema.fields().iter().map(|f| f.name().clone()).collect());
@@ -384,6 +395,7 @@ pub fn ingest_vcfs(
         variant_count,
         filtered_contigs,
         multiallelic_split,
+        genotype_variants,
     })
 }
 
@@ -417,11 +429,13 @@ fn get_or_create_writer<'a>(
 }
 
 /// Process a single VCF record — split multi-allelics, normalize, route to per-chrom writer.
+/// When `geno_writer` is Some, dosages are extracted in the same pass.
 #[allow(clippy::too_many_arguments)]
 fn process_record(
     record: &noodles_vcf::Record,
     writers: &mut HashMap<&'static str, ChromWriter>,
     vs_writer: &VariantSetWriter,
+    mut geno_writer: Option<&mut GenotypeWriter>,
     schema: &Arc<Schema>,
     props: &WriterProperties,
     batch_size: usize,
@@ -475,9 +489,16 @@ fn process_record(
         *multiallelic_split += alts.len() as u64 - 1;
     }
 
-    for alt in &alts {
+    let samples_str = if geno_writer.is_some() {
+        let s = record.samples();
+        let raw: &str = s.as_ref();
+        Some(raw.to_string())
+    } else {
+        None
+    };
+
+    for (alt_idx, alt) in alts.iter().enumerate() {
         let alt_upper = alt.trim().to_uppercase();
-        // Skip missing, spanning deletion, and symbolic alleles (<DEL>, <INS>, etc.)
         if alt_upper == "*"
             || alt_upper == "."
             || alt_upper.is_empty()
@@ -508,6 +529,18 @@ fn process_record(
             cw.writer
                 .write(&rb)
                 .map_err(|e| CohortError::Resource(format!("Parquet write error: {e}")))?;
+        }
+
+        if let Some(ref mut gw) = geno_writer {
+            gw.push(
+                chrom,
+                norm_pos,
+                &norm_ref,
+                &norm_alt,
+                samples_str.as_deref().unwrap_or(""),
+                (alt_idx + 1) as u8,
+                output,
+            )?;
         }
     }
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -200,6 +200,8 @@ fn run(
             masks,
             maf_cutoff,
             window_size,
+            known_loci,
+            conditional_model,
             output: output_path,
         } => {
             let engine = runtime::Engine::open(store_path)?;
@@ -208,6 +210,8 @@ fn run(
                 masks,
                 maf_cutoff,
                 window_size,
+                known_loci,
+                conditional_model,
                 output_path,
             )?;
             commands::meta_staar::run_meta_staar(&engine, &config, out, dry_run)

--- a/src/staar/genotype.rs
+++ b/src/staar/genotype.rs
@@ -30,7 +30,7 @@ pub struct GenotypeMeta {
     pub version: u32,
     pub n_samples: usize,
     pub chromosomes: Vec<String>,
-    pub source_vcf: String,
+    pub source_vcfs: Vec<String>,
 }
 
 pub struct GenotypeResult {
@@ -39,13 +39,17 @@ pub struct GenotypeResult {
 }
 
 pub fn extract_genotypes(
-    vcf_path: &Path,
+    vcf_paths: &[PathBuf],
     output_dir: &Path,
     available_memory: u64,
     threads: usize,
     output: &dyn Output,
 ) -> Result<GenotypeResult, CohortError> {
-    let reader = open_vcf(vcf_path, threads)?;
+    if vcf_paths.is_empty() {
+        return Err(CohortError::Input("No VCF files provided.".into()));
+    }
+
+    let reader = open_vcf(&vcf_paths[0], threads)?;
     let mut vcf_reader = noodles_vcf::io::Reader::new(reader);
     let header = vcf_reader
         .read_header()
@@ -62,146 +66,276 @@ pub fn extract_genotypes(
             "VCF has no samples. STAAR requires a multi-sample VCF.".into(),
         ));
     }
+    drop(vcf_reader);
 
     output.status(&format!(
-        "Extracting genotypes: {} samples, {} decompression threads, {:.1}G memory",
+        "Extracting genotypes: {} samples, {} file(s), {} threads, {:.1}G memory",
         n_samples,
+        vcf_paths.len(),
         threads,
         available_memory as f64 / (1024.0 * 1024.0 * 1024.0)
     ));
 
-    let bytes_per_variant = (n_samples as u64) * 4 + 200;
-    let batch_size = ((available_memory / 4) / bytes_per_variant).clamp(1000, 100_000) as usize;
-
-    // Schema: 5 metadata columns + 1 packed dosage list
-    let schema = Arc::new(packed_schema(n_samples));
     let geno_dir = output_dir.join("genotypes");
-    std::fs::create_dir_all(&geno_dir).map_err(|e| {
-        CohortError::Resource(format!("Cannot create '{}': {e}", geno_dir.display()))
-    })?;
+    let mut gw = GenotypeWriter::new(n_samples, &geno_dir, available_memory)?;
 
-    let props = WriterProperties::builder()
-        .set_compression(Compression::ZSTD(Default::default()))
-        .set_max_row_group_row_count(Some(batch_size))
-        .build();
-
-    let mut state = ExtractState {
-        current_chrom: None,
-        writer: None,
-        batch: PackedBatchBuilder::new(n_samples, batch_size),
-        total_variants: 0,
-        chromosomes: Vec::new(),
-        dosages: vec![f32::NAN; n_samples],
-    };
-
+    let mut finished_chroms: std::collections::HashSet<String> = std::collections::HashSet::new();
     let pb = output.progress(0, "extracting genotypes");
-    for result in vcf_reader.records() {
-        let record = result.map_err(|e| {
-            CohortError::Analysis(format!("VCF parse error in '{}': {e}", vcf_path.display()))
-        })?;
-        process_record(
-            &record, n_samples, &mut state, &schema, &props, &geno_dir, output,
-        )?;
-        pb.inc(1);
+
+    for (file_idx, vcf_path) in vcf_paths.iter().enumerate() {
+        let reader = open_vcf(vcf_path, threads)?;
+        let mut vcf_reader = noodles_vcf::io::Reader::new(reader);
+        let file_header = vcf_reader
+            .read_header()
+            .map_err(|e| CohortError::Input(format!("VCF header in '{}': {e}", vcf_path.display())))?;
+
+        if file_idx > 0 {
+            let file_samples: Vec<String> = file_header
+                .sample_names()
+                .iter()
+                .map(|s| s.to_string())
+                .collect();
+            if file_samples != sample_names {
+                return Err(CohortError::Input(format!(
+                    "Sample mismatch: '{}' has {} samples but '{}' has {}. \
+                     All VCF files must have identical samples in the same order.",
+                    vcf_paths[0].display(),
+                    sample_names.len(),
+                    vcf_path.display(),
+                    file_samples.len()
+                )));
+            }
+        }
+
+        for result in vcf_reader.records() {
+            let record = result.map_err(|e| {
+                CohortError::Analysis(format!("VCF parse error in '{}': {e}", vcf_path.display()))
+            })?;
+
+            let raw_chrom = record.reference_sequence_name();
+            if let Some(chrom) = normalize_chrom(raw_chrom) {
+                if gw.current_chrom.as_deref() != Some(chrom) && finished_chroms.contains(chrom) {
+                    return Err(CohortError::Input(format!(
+                        "Chromosome {chrom} appears in '{}' but its writer was already \
+                         closed after processing an earlier file. Sort VCF files by \
+                         chromosome or use one file per chromosome.",
+                        vcf_path.display()
+                    )));
+                }
+            }
+
+            process_record_geno(&record, &mut gw, output)?;
+            pb.inc(1);
+        }
+
+        if let Some(ref current) = gw.current_chrom {
+            for c in &gw.chromosomes {
+                if c != current {
+                    finished_chroms.insert(c.clone());
+                }
+            }
+        }
     }
-    pb.finish(&format!("{} variants extracted", state.total_variants));
+    pb.finish(&format!("{} variants extracted", gw.variant_count()));
 
-    flush(&mut state, &schema)?;
-    if let Some(w) = state.writer.take() {
-        w.close()
-            .map_err(|e| CohortError::Resource(format!("Parquet close: {e}")))?;
-    }
-
-    // Write sample names sidecar (order matters for unpacking dosages)
-    let sidecar = geno_dir.join("samples.txt");
-    std::fs::write(&sidecar, sample_names.join("\n"))
-        .map_err(|e| CohortError::Resource(format!("Cannot write '{}': {e}", sidecar.display())))?;
-
-    // Write metadata — this is the last step so partial extractions are detectable
-    let meta = GenotypeMeta {
-        version: 1,
-        n_samples,
-        chromosomes: state.chromosomes.clone(),
-        source_vcf: vcf_path.display().to_string(),
-    };
-    let meta_path = geno_dir.join("genotypes.json");
-    std::fs::write(
-        &meta_path,
-        serde_json::to_string_pretty(&meta)
-            .map_err(|e| CohortError::Resource(format!("JSON serialize: {e}")))?,
-    )
-    .map_err(|e| CohortError::Resource(format!("Cannot write '{}': {e}", meta_path.display())))?;
+    let source_vcfs = vcf_paths.iter().map(|p| p.display().to_string()).collect();
+    let result = gw.finish(&sample_names, source_vcfs)?;
 
     output.success(&format!(
-        "Extracted {} variants × {} samples → packed dosage lists",
-        state.total_variants, n_samples,
+        "Extracted {} variants × {} samples from {} file(s)",
+        result.output_dir.display(), n_samples, vcf_paths.len(),
     ));
 
-    Ok(GenotypeResult {
-        sample_names,
-        output_dir: geno_dir,
-    })
+    Ok(result)
 }
 
-struct ExtractState {
+/// Reusable genotype writer. Accepts already-normalized variants and raw
+/// VCF sample text, writes per-chromosome dosage parquets. Used both by
+/// the standalone `extract_genotypes` path and by the single-pass ingest
+/// path in `ingest/vcf.rs`.
+pub struct GenotypeWriter {
     current_chrom: Option<String>,
     writer: Option<ArrowWriter<File>>,
     batch: PackedBatchBuilder,
     total_variants: u64,
     chromosomes: Vec<String>,
-    /// Reusable per-variant dosage buffer. Cleared between records so the
-    /// hot path never allocates.
     dosages: Vec<f32>,
-}
-
-fn flush(state: &mut ExtractState, schema: &Arc<Schema>) -> Result<(), CohortError> {
-    if state.batch.count > 0 {
-        if let Some(w) = state.writer.as_mut() {
-            let rb = state.batch.finish(schema)?;
-            w.write(&rb)
-                .map_err(|e| CohortError::Resource(format!("Parquet write: {e}")))?;
-        }
-    }
-    Ok(())
-}
-
-fn switch_chrom(
-    chrom: &str,
-    state: &mut ExtractState,
-    schema: &Arc<Schema>,
-    props: &WriterProperties,
-    geno_dir: &Path,
-    output: &dyn Output,
-) -> Result<(), CohortError> {
-    flush(state, schema)?;
-    if let Some(w) = state.writer.take() {
-        w.close()
-            .map_err(|e| CohortError::Resource(format!("Parquet close: {e}")))?;
-    }
-    let chr_dir = geno_dir.join(format!("chromosome={chrom}"));
-    std::fs::create_dir_all(&chr_dir)
-        .map_err(|e| CohortError::Resource(format!("Cannot create '{}': {e}", chr_dir.display())))?;
-    let parquet_path = chr_dir.join("data.parquet");
-    let f = File::create(&parquet_path).map_err(|e| {
-        CohortError::Resource(format!("Cannot create '{}': {e}", parquet_path.display()))
-    })?;
-    state.writer = Some(
-        ArrowWriter::try_new(f, schema.clone(), Some(props.clone()))
-            .map_err(|e| CohortError::Resource(format!("Writer init: {e}")))?,
-    );
-    state.current_chrom = Some(chrom.to_string());
-    state.chromosomes.push(chrom.to_string());
-    output.status(&format!("  chr{chrom}..."));
-    Ok(())
-}
-
-fn process_record(
-    record: &noodles_vcf::Record,
     n_samples: usize,
-    state: &mut ExtractState,
-    schema: &Arc<Schema>,
-    props: &WriterProperties,
-    geno_dir: &Path,
+    schema: Arc<Schema>,
+    props: WriterProperties,
+    geno_dir: PathBuf,
+}
+
+impl GenotypeWriter {
+    pub fn new(
+        n_samples: usize,
+        output_dir: &Path,
+        available_memory: u64,
+    ) -> Result<Self, CohortError> {
+        let bytes_per_variant = (n_samples as u64) * 4 + 200;
+        let batch_size =
+            ((available_memory / 4) / bytes_per_variant).clamp(1000, 100_000) as usize;
+
+        let geno_dir = output_dir.to_path_buf();
+        std::fs::create_dir_all(&geno_dir).map_err(|e| {
+            CohortError::Resource(format!("Cannot create '{}': {e}", geno_dir.display()))
+        })?;
+
+        let schema = Arc::new(packed_schema(n_samples));
+        let props = WriterProperties::builder()
+            .set_compression(Compression::ZSTD(Default::default()))
+            .set_max_row_group_row_count(Some(batch_size))
+            .build();
+
+        Ok(Self {
+            current_chrom: None,
+            writer: None,
+            batch: PackedBatchBuilder::new(n_samples, batch_size),
+            total_variants: 0,
+            chromosomes: Vec::new(),
+            dosages: vec![f32::NAN; n_samples],
+            n_samples,
+            schema,
+            props,
+            geno_dir,
+        })
+    }
+
+    /// Push one biallelic variant with dosages extracted from raw VCF sample text.
+    /// `chrom` and `pos/ref/alt` must already be normalized.
+    /// `alt_idx` is the 1-based index of this alt allele in the original record.
+    pub fn push(
+        &mut self,
+        chrom: &str,
+        pos: i32,
+        ref_allele: &str,
+        alt_allele: &str,
+        samples_str: &str,
+        alt_idx: u8,
+        output: &dyn Output,
+    ) -> Result<(), CohortError> {
+        if self.current_chrom.as_deref() != Some(chrom) {
+            self.switch_chrom(chrom, output)?;
+        }
+
+        for d in self.dosages.iter_mut() {
+            *d = f32::NAN;
+        }
+        let mut ac: f64 = 0.0;
+        let mut an: f64 = 0.0;
+
+        if !samples_str.is_empty() && samples_str != "." {
+            for (i, sf) in samples_str.split('\t').enumerate().take(self.n_samples) {
+                let gt = extract_gt_field(sf, 0);
+                let dose = gt_to_dosage(gt.as_bytes(), alt_idx);
+                self.dosages[i] = dose;
+                if dose.is_finite() {
+                    ac += dose as f64;
+                    an += 2.0;
+                }
+            }
+        }
+
+        let af = if an > 0.0 { ac / an } else { 0.0 };
+        let maf = af.min(1.0 - af) as f32;
+
+        let dosages: &[f32] = &self.dosages;
+        self.batch
+            .push(chrom, pos, ref_allele, alt_allele, maf, dosages);
+        self.total_variants += 1;
+
+        if self.batch.is_full() {
+            self.flush()?;
+        }
+        Ok(())
+    }
+
+    pub fn variant_count(&self) -> u64 {
+        self.total_variants
+    }
+
+    /// Finalize: flush remaining batches, close writers, write samples sidecar
+    /// and metadata. Returns the output directory path and chromosome list.
+    pub fn finish(
+        mut self,
+        sample_names: &[String],
+        source_vcfs: Vec<String>,
+    ) -> Result<GenotypeResult, CohortError> {
+        self.flush()?;
+        if let Some(w) = self.writer.take() {
+            w.close()
+                .map_err(|e| CohortError::Resource(format!("Parquet close: {e}")))?;
+        }
+
+        let sidecar = self.geno_dir.join("samples.txt");
+        std::fs::write(&sidecar, sample_names.join("\n"))
+            .map_err(|e| {
+                CohortError::Resource(format!("Cannot write '{}': {e}", sidecar.display()))
+            })?;
+
+        let meta = GenotypeMeta {
+            version: 1,
+            n_samples: self.n_samples,
+            chromosomes: self.chromosomes.clone(),
+            source_vcfs,
+        };
+        let meta_path = self.geno_dir.join("genotypes.json");
+        std::fs::write(
+            &meta_path,
+            serde_json::to_string_pretty(&meta)
+                .map_err(|e| CohortError::Resource(format!("JSON serialize: {e}")))?,
+        )
+        .map_err(|e| {
+            CohortError::Resource(format!("Cannot write '{}': {e}", meta_path.display()))
+        })?;
+
+        Ok(GenotypeResult {
+            sample_names: sample_names.to_vec(),
+            output_dir: self.geno_dir,
+        })
+    }
+
+    fn flush(&mut self) -> Result<(), CohortError> {
+        if self.batch.count > 0 {
+            if let Some(w) = self.writer.as_mut() {
+                let rb = self.batch.finish(&self.schema)?;
+                w.write(&rb)
+                    .map_err(|e| CohortError::Resource(format!("Parquet write: {e}")))?;
+            }
+        }
+        Ok(())
+    }
+
+    fn switch_chrom(&mut self, chrom: &str, output: &dyn Output) -> Result<(), CohortError> {
+        self.flush()?;
+        if let Some(w) = self.writer.take() {
+            w.close()
+                .map_err(|e| CohortError::Resource(format!("Parquet close: {e}")))?;
+        }
+        let chr_dir = self.geno_dir.join(format!("chromosome={chrom}"));
+        std::fs::create_dir_all(&chr_dir).map_err(|e| {
+            CohortError::Resource(format!("Cannot create '{}': {e}", chr_dir.display()))
+        })?;
+        let parquet_path = chr_dir.join("data.parquet");
+        let f = File::create(&parquet_path).map_err(|e| {
+            CohortError::Resource(format!("Cannot create '{}': {e}", parquet_path.display()))
+        })?;
+        self.writer = Some(
+            ArrowWriter::try_new(f, self.schema.clone(), Some(self.props.clone()))
+                .map_err(|e| CohortError::Resource(format!("Writer init: {e}")))?,
+        );
+        self.current_chrom = Some(chrom.to_string());
+        self.chromosomes.push(chrom.to_string());
+        output.status(&format!("  chr{chrom} (genotypes)..."));
+        Ok(())
+    }
+}
+
+/// Process a single VCF record through the GenotypeWriter. Used by the
+/// standalone `extract_genotypes` path.
+fn process_record_geno(
+    record: &noodles_vcf::Record,
+    gw: &mut GenotypeWriter,
     output: &dyn Output,
 ) -> Result<(), CohortError> {
     let raw_chrom = record.reference_sequence_name();
@@ -209,10 +343,6 @@ fn process_record(
         Some(c) => c,
         None => return Ok(()),
     };
-
-    if state.current_chrom.as_deref() != Some(chrom) {
-        switch_chrom(chrom, state, schema, props, geno_dir, output)?;
-    }
 
     let pos = match record.variant_start() {
         Some(Ok(p)) => p.get() as i32,
@@ -226,7 +356,6 @@ fn process_record(
 
     let samples_raw = record.samples();
     let samples_str: &str = samples_raw.as_ref();
-    let gt_index = 0; // GT is first FORMAT field by VCF spec
 
     for (alt_idx, alt) in alts.iter().enumerate() {
         let alt_upper = alt.trim().to_uppercase();
@@ -235,43 +364,15 @@ fn process_record(
         }
 
         let (norm_ref, norm_alt, norm_pos) = parsimony_normalize(&ref_allele, &alt_upper, pos);
-
-        // Reuse the per-variant dosage buffer; reset to NaN per call so any
-        // VCF row with fewer than n_samples sample fields is treated as
-        // missing for the unset positions.
-        for d in state.dosages.iter_mut() {
-            *d = f32::NAN;
-        }
-        let mut ac: f64 = 0.0;
-        let mut an: f64 = 0.0;
-
-        if !samples_str.is_empty() && samples_str != "." {
-            for (i, sf) in samples_str.split('\t').enumerate().take(n_samples) {
-                let gt = extract_gt_field(sf, gt_index);
-                let dose = gt_to_dosage(gt.as_bytes(), (alt_idx + 1) as u8);
-                state.dosages[i] = dose;
-                if dose.is_finite() {
-                    ac += dose as f64;
-                    an += 2.0;
-                }
-            }
-        }
-
-        let af = if an > 0.0 { ac / an } else { 0.0 };
-        let maf = af.min(1.0 - af) as f32;
-
-        // Disjoint-field borrow: batch and dosages are independent fields
-        // of state, but the call expression `state.batch.push(..., &state.dosages)`
-        // confuses the borrow checker, so split it explicitly.
-        let dosages: &[f32] = &state.dosages;
-        state
-            .batch
-            .push(chrom, norm_pos, &norm_ref, &norm_alt, maf, dosages);
-        state.total_variants += 1;
-
-        if state.batch.is_full() {
-            flush(state, schema)?;
-        }
+        gw.push(
+            chrom,
+            norm_pos,
+            &norm_ref,
+            &norm_alt,
+            samples_str,
+            (alt_idx + 1) as u8,
+            output,
+        )?;
     }
 
     Ok(())

--- a/src/staar/genotype.rs
+++ b/src/staar/genotype.rs
@@ -138,12 +138,13 @@ pub fn extract_genotypes(
     }
     pb.finish(&format!("{} variants extracted", gw.variant_count()));
 
+    let total_variants = gw.variant_count();
     let source_vcfs = vcf_paths.iter().map(|p| p.display().to_string()).collect();
     let result = gw.finish(&sample_names, source_vcfs)?;
 
     output.success(&format!(
-        "Extracted {} variants × {} samples from {} file(s)",
-        result.output_dir.display(), n_samples, vcf_paths.len(),
+        "Extracted {total_variants} variants × {n_samples} samples from {} file(s)",
+        vcf_paths.len(),
     ));
 
     Ok(result)
@@ -204,6 +205,7 @@ impl GenotypeWriter {
     /// Push one biallelic variant with dosages extracted from raw VCF sample text.
     /// `chrom` and `pos/ref/alt` must already be normalized.
     /// `alt_idx` is the 1-based index of this alt allele in the original record.
+    #[allow(clippy::too_many_arguments)]
     pub fn push(
         &mut self,
         chrom: &str,

--- a/src/staar/meta.rs
+++ b/src/staar/meta.rs
@@ -1132,6 +1132,356 @@ fn write_record_batch(
     Ok(())
 }
 
+/// Parse a known-loci file into (chrom_label, position, ref, alt) tuples.
+/// Format: one `chr:pos:ref:alt` per line; `#` comments and empty lines skipped.
+/// Lines with only `chr:pos` are accepted (ref/alt set to "*" wildcard).
+pub fn parse_known_loci_file(
+    path: &Path,
+) -> Result<Vec<(String, u32, String, String)>, CohortError> {
+    let content = std::fs::read_to_string(path).map_err(|e| {
+        CohortError::Resource(format!(
+            "Cannot read known loci file '{}': {e}",
+            path.display()
+        ))
+    })?;
+    let loci: Vec<(String, u32, String, String)> = content
+        .lines()
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .filter_map(|l| {
+            let parts: Vec<&str> = l.split(':').collect();
+            if parts.len() < 2 {
+                return None;
+            }
+            let chrom: crate::types::Chromosome = parts[0].parse().ok()?;
+            let pos = parts[1].parse::<u32>().ok()?;
+            let ref_a = parts.get(2).unwrap_or(&"*").to_string();
+            let alt_a = parts.get(3).unwrap_or(&"*").to_string();
+            Some((chrom.label().to_string(), pos, ref_a, alt_a))
+        })
+        .collect();
+    if loci.is_empty() {
+        return Err(CohortError::Input(format!(
+            "Known loci file '{}' is empty or unparseable.",
+            path.display()
+        )));
+    }
+    Ok(loci)
+}
+
+/// Conditional meta-analysis: condition gene-level U/K on known loci
+/// before running STAAR tests.
+///
+/// Homogeneous model: condition the merged (cross-study) U and K.
+/// Heterogeneous model: condition per-study U and K before merging.
+///
+/// The conditioning step uses Schur complement:
+///   U_cond = U_t - K_tc * K_cc^{-1} * U_c
+///   K_cond = K_tt - K_tc * K_cc^{-1} * K_ct
+///
+/// where t = test (gene) variants, c = conditioning (known loci) variants.
+pub fn meta_score_gene_conditional(
+    group: &MaskGroup,
+    meta_variants: &[MetaVariant],
+    studies: &[StudyHandle],
+    segment_cache: &HashMap<(usize, i32), SegmentCov>,
+    known_loci_indices: &[usize],
+    heterogeneous: bool,
+) -> Option<GeneResult> {
+    let gene_indices: Vec<usize> = group
+        .variant_indices
+        .iter()
+        .filter(|&&i| i < meta_variants.len())
+        .copied()
+        .collect();
+    if gene_indices.len() < 2 {
+        return None;
+    }
+
+    // Filter known loci to those actually present in meta_variants
+    // and not overlapping with the gene's own variants.
+    let gene_set: std::collections::HashSet<usize> = gene_indices.iter().copied().collect();
+    let cond_indices: Vec<usize> = known_loci_indices
+        .iter()
+        .filter(|&&i| i < meta_variants.len() && !gene_set.contains(&i))
+        .copied()
+        .collect();
+
+    // No conditioning loci in range: fall back to unconditional.
+    if cond_indices.is_empty() {
+        return meta_score_gene(group, meta_variants, studies, segment_cache);
+    }
+
+    let m_t = gene_indices.len();
+    let m_c = cond_indices.len();
+
+    // Build combined keys: [gene variants | conditioning variants].
+    let combined: Vec<usize> = gene_indices
+        .iter()
+        .chain(cond_indices.iter())
+        .copied()
+        .collect();
+    let m_all = combined.len();
+
+    if heterogeneous {
+        // Heterogeneous: condition per-study, then sum.
+        let mut u_cond = Mat::zeros(m_t, 1);
+        let mut k_cond = Mat::zeros(m_t, m_t);
+
+        for study_idx in 0..studies.len() {
+            let (u_s, cov_s) =
+                build_study_u_cov(&combined, meta_variants, study_idx, segment_cache);
+            let (u_t_s, k_tt_s, u_c_s, k_cc_s, k_tc_s) =
+                partition_u_cov(&u_s, &cov_s, m_t, m_c);
+            let (du, dk) = schur_condition(&u_t_s, &k_tt_s, &u_c_s, &k_cc_s, &k_tc_s);
+            for i in 0..m_t {
+                u_cond[(i, 0)] += du[(i, 0)];
+                for j in 0..m_t {
+                    k_cond[(i, j)] += dk[(i, j)];
+                }
+            }
+        }
+
+        return finish_conditional(
+            &gene_indices,
+            meta_variants,
+            &u_cond,
+            &k_cond,
+            group,
+        );
+    }
+
+    // Homogeneous: condition merged U/K.
+    let mut u_all = Mat::zeros(m_all, 1);
+    for (local, &gi) in combined.iter().enumerate() {
+        u_all[(local, 0)] = meta_variants[gi].u_meta;
+    }
+
+    let keys: Vec<(u32, &str, &str)> = combined
+        .iter()
+        .map(|&gi| {
+            (
+                meta_variants[gi].variant.position,
+                &*meta_variants[gi].variant.ref_allele,
+                &*meta_variants[gi].variant.alt_allele,
+            )
+        })
+        .collect();
+
+    let mut cov_all = Mat::zeros(m_all, m_all);
+    for study_idx in 0..studies.len() {
+        let mut needed_segments: std::collections::HashSet<i32> =
+            std::collections::HashSet::new();
+        for &gi in &combined {
+            for &(sidx, seg_id) in &meta_variants[gi].study_segments {
+                if sidx == study_idx {
+                    needed_segments.insert(seg_id);
+                }
+            }
+        }
+        for seg_id in needed_segments {
+            if let Some(seg) = segment_cache.get(&(study_idx, seg_id)) {
+                let sub = seg.extract_submatrix(&keys);
+                for i in 0..m_all {
+                    for j in 0..m_all {
+                        cov_all[(i, j)] += sub[(i, j)];
+                    }
+                }
+            }
+        }
+    }
+
+    let (u_t, k_tt, u_c, k_cc, k_tc) = partition_u_cov(&u_all, &cov_all, m_t, m_c);
+    let (u_cond, k_cond) = schur_condition(&u_t, &k_tt, &u_c, &k_cc, &k_tc);
+
+    finish_conditional(&gene_indices, meta_variants, &u_cond, &k_cond, group)
+}
+
+/// Build per-study U and covariance for a combined set of variant indices.
+fn build_study_u_cov(
+    combined: &[usize],
+    meta_variants: &[MetaVariant],
+    study_idx: usize,
+    segment_cache: &HashMap<(usize, i32), SegmentCov>,
+) -> (Mat<f64>, Mat<f64>) {
+    let m = combined.len();
+    let mut u = Mat::zeros(m, 1);
+    // Per-study U is stored as part of the segment data. For simplicity,
+    // use the meta-aggregated U scaled by (study_n / total_n) as an
+    // approximation. The exact per-study U would require storing per-study
+    // score vectors, which emit-sumstats does not currently persist at the
+    // variant level. This is standard practice in meta-STAAR.
+    let study_n = meta_variants
+        .iter()
+        .flat_map(|mv| mv.study_segments.iter())
+        .filter(|&&(s, _)| s == study_idx)
+        .count();
+    let _ = study_n; // unused — u_meta is already the sum
+    for (local, &gi) in combined.iter().enumerate() {
+        // Use aggregated U — the conditioning math holds for sum(U_s) and
+        // sum(K_s) under the homogeneous assumption.
+        u[(local, 0)] = meta_variants[gi].u_meta;
+    }
+
+    let keys: Vec<(u32, &str, &str)> = combined
+        .iter()
+        .map(|&gi| {
+            (
+                meta_variants[gi].variant.position,
+                &*meta_variants[gi].variant.ref_allele,
+                &*meta_variants[gi].variant.alt_allele,
+            )
+        })
+        .collect();
+
+    let mut cov = Mat::zeros(m, m);
+    let mut needed_segments: std::collections::HashSet<i32> = std::collections::HashSet::new();
+    for &gi in combined {
+        for &(sidx, seg_id) in &meta_variants[gi].study_segments {
+            if sidx == study_idx {
+                needed_segments.insert(seg_id);
+            }
+        }
+    }
+    for seg_id in needed_segments {
+        if let Some(seg) = segment_cache.get(&(study_idx, seg_id)) {
+            let sub = seg.extract_submatrix(&keys);
+            for i in 0..m {
+                for j in 0..m {
+                    cov[(i, j)] += sub[(i, j)];
+                }
+            }
+        }
+    }
+    (u, cov)
+}
+
+/// Partition combined U and K into test (t) and conditioning (c) blocks.
+fn partition_u_cov(
+    u: &Mat<f64>,
+    k: &Mat<f64>,
+    m_t: usize,
+    m_c: usize,
+) -> (Mat<f64>, Mat<f64>, Mat<f64>, Mat<f64>, Mat<f64>) {
+    let u_t = u.subrows(0, m_t).to_owned();
+    let u_c = u.subrows(m_t, m_c).to_owned();
+    let k_tt = k.submatrix(0, 0, m_t, m_t).to_owned();
+    let k_cc = k.submatrix(m_t, m_t, m_c, m_c).to_owned();
+    let k_tc = k.submatrix(0, m_t, m_t, m_c).to_owned();
+    (u_t, k_tt, u_c, k_cc, k_tc)
+}
+
+/// Schur complement conditioning:
+///   U_cond = U_t - K_tc * K_cc^{-1} * U_c
+///   K_cond = K_tt - K_tc * K_cc^{-1} * K_ct
+fn schur_condition(
+    u_t: &Mat<f64>,
+    k_tt: &Mat<f64>,
+    u_c: &Mat<f64>,
+    k_cc: &Mat<f64>,
+    k_tc: &Mat<f64>,
+) -> (Mat<f64>, Mat<f64>) {
+    use faer::linalg::solvers::Solve;
+
+    let m_t = u_t.nrows();
+    let m_c = u_c.nrows();
+
+    if m_c == 0 {
+        return (u_t.to_owned(), k_tt.to_owned());
+    }
+
+    // Regularize K_cc for numerical stability.
+    let mut k_cc_reg = k_cc.to_owned();
+    for i in 0..m_c {
+        k_cc_reg[(i, i)] += 1e-8;
+    }
+
+    // K_cc^{-1} via column-pivoted QR (robust for small m_c).
+    let k_cc_inv = {
+        let eye = Mat::identity(m_c, m_c);
+        k_cc_reg.col_piv_qr().solve(&eye)
+    };
+
+    // K_tc * K_cc^{-1}
+    let k_tc_kinv = k_tc * &k_cc_inv;
+
+    // U_cond = U_t - K_tc * K_cc^{-1} * U_c
+    let mut u_cond = u_t.to_owned();
+    let correction_u = &k_tc_kinv * u_c;
+    for i in 0..m_t {
+        u_cond[(i, 0)] -= correction_u[(i, 0)];
+    }
+
+    // K_cond = K_tt - K_tc * K_cc^{-1} * K_ct
+    let k_ct = k_tc.transpose().to_owned();
+    let correction_k = &k_tc_kinv * &k_ct;
+    let mut k_cond = k_tt.to_owned();
+    for i in 0..m_t {
+        for j in 0..m_t {
+            k_cond[(i, j)] -= correction_k[(i, j)];
+        }
+    }
+
+    (u_cond, k_cond)
+}
+
+/// Finish conditional scoring: compute MAFs, annotation weights, run STAAR.
+fn finish_conditional(
+    gene_indices: &[usize],
+    meta_variants: &[MetaVariant],
+    u_cond: &Mat<f64>,
+    k_cond: &Mat<f64>,
+    group: &MaskGroup,
+) -> Option<GeneResult> {
+    let m_t = gene_indices.len();
+
+    let mafs: Vec<f64> = gene_indices
+        .iter()
+        .map(|&gi| {
+            let mv = &meta_variants[gi];
+            if mv.n_total > 0 {
+                mv.mac_total as f64 / (2.0 * mv.n_total as f64)
+            } else {
+                0.0
+            }
+        })
+        .collect();
+
+    let n_total: usize = gene_indices
+        .iter()
+        .map(|&gi| meta_variants[gi].n_total as usize)
+        .max()
+        .unwrap_or(0);
+
+    let ann_matrix: Vec<Vec<f64>> = (0..11)
+        .map(|ch| {
+            gene_indices
+                .iter()
+                .map(|&gi| meta_variants[gi].variant.annotation.weights.0[ch])
+                .collect()
+        })
+        .collect();
+
+    let sr = score::run_staar_from_sumstats(u_cond, k_cond, &ann_matrix, &mafs, n_total);
+    let (burden_beta, burden_se) = unweighted_burden_estimate(u_cond, k_cond);
+    let cmac: i64 = gene_indices
+        .iter()
+        .map(|&gi| meta_variants[gi].mac_total)
+        .sum();
+
+    Some(GeneResult {
+        ensembl_id: group.name.clone(),
+        gene_symbol: group.name.clone(),
+        chromosome: group.chromosome,
+        start: group.start,
+        end: group.end,
+        n_variants: m_t as u32,
+        cumulative_mac: cmac as u32,
+        staar: sr,
+        burden_beta,
+        burden_se,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/staar/meta.rs
+++ b/src/staar/meta.rs
@@ -1179,13 +1179,17 @@ pub fn parse_known_loci_file(
 ///   K_cond = K_tt - K_tc * K_cc^{-1} * K_ct
 ///
 /// where t = test (gene) variants, c = conditioning (known loci) variants.
+/// Conditional meta-scoring uses the homogeneous model: condition the
+/// merged (cross-study) U and K on known-loci variants via Schur complement.
+/// The heterogeneous model (per-study conditioning) is rejected at config
+/// time because --emit-sumstats does not yet persist per-study U vectors.
 pub fn meta_score_gene_conditional(
     group: &MaskGroup,
     meta_variants: &[MetaVariant],
     studies: &[StudyHandle],
     segment_cache: &HashMap<(usize, i32), SegmentCov>,
     known_loci_indices: &[usize],
-    heterogeneous: bool,
+    _heterogeneous: bool,
 ) -> Option<GeneResult> {
     let gene_indices: Vec<usize> = group
         .variant_indices
@@ -1221,34 +1225,6 @@ pub fn meta_score_gene_conditional(
         .copied()
         .collect();
     let m_all = combined.len();
-
-    if heterogeneous {
-        // Heterogeneous: condition per-study, then sum.
-        let mut u_cond = Mat::zeros(m_t, 1);
-        let mut k_cond = Mat::zeros(m_t, m_t);
-
-        for study_idx in 0..studies.len() {
-            let (u_s, cov_s) =
-                build_study_u_cov(&combined, meta_variants, study_idx, segment_cache);
-            let (u_t_s, k_tt_s, u_c_s, k_cc_s, k_tc_s) =
-                partition_u_cov(&u_s, &cov_s, m_t, m_c);
-            let (du, dk) = schur_condition(&u_t_s, &k_tt_s, &u_c_s, &k_cc_s, &k_tc_s);
-            for i in 0..m_t {
-                u_cond[(i, 0)] += du[(i, 0)];
-                for j in 0..m_t {
-                    k_cond[(i, j)] += dk[(i, j)];
-                }
-            }
-        }
-
-        return finish_conditional(
-            &gene_indices,
-            meta_variants,
-            &u_cond,
-            &k_cond,
-            group,
-        );
-    }
 
     // Homogeneous: condition merged U/K.
     let mut u_all = Mat::zeros(m_all, 1);
@@ -1296,66 +1272,8 @@ pub fn meta_score_gene_conditional(
     finish_conditional(&gene_indices, meta_variants, &u_cond, &k_cond, group)
 }
 
-/// Build per-study U and covariance for a combined set of variant indices.
-fn build_study_u_cov(
-    combined: &[usize],
-    meta_variants: &[MetaVariant],
-    study_idx: usize,
-    segment_cache: &HashMap<(usize, i32), SegmentCov>,
-) -> (Mat<f64>, Mat<f64>) {
-    let m = combined.len();
-    let mut u = Mat::zeros(m, 1);
-    // Per-study U is stored as part of the segment data. For simplicity,
-    // use the meta-aggregated U scaled by (study_n / total_n) as an
-    // approximation. The exact per-study U would require storing per-study
-    // score vectors, which emit-sumstats does not currently persist at the
-    // variant level. This is standard practice in meta-STAAR.
-    let study_n = meta_variants
-        .iter()
-        .flat_map(|mv| mv.study_segments.iter())
-        .filter(|&&(s, _)| s == study_idx)
-        .count();
-    let _ = study_n; // unused — u_meta is already the sum
-    for (local, &gi) in combined.iter().enumerate() {
-        // Use aggregated U — the conditioning math holds for sum(U_s) and
-        // sum(K_s) under the homogeneous assumption.
-        u[(local, 0)] = meta_variants[gi].u_meta;
-    }
-
-    let keys: Vec<(u32, &str, &str)> = combined
-        .iter()
-        .map(|&gi| {
-            (
-                meta_variants[gi].variant.position,
-                &*meta_variants[gi].variant.ref_allele,
-                &*meta_variants[gi].variant.alt_allele,
-            )
-        })
-        .collect();
-
-    let mut cov = Mat::zeros(m, m);
-    let mut needed_segments: std::collections::HashSet<i32> = std::collections::HashSet::new();
-    for &gi in combined {
-        for &(sidx, seg_id) in &meta_variants[gi].study_segments {
-            if sidx == study_idx {
-                needed_segments.insert(seg_id);
-            }
-        }
-    }
-    for seg_id in needed_segments {
-        if let Some(seg) = segment_cache.get(&(study_idx, seg_id)) {
-            let sub = seg.extract_submatrix(&keys);
-            for i in 0..m {
-                for j in 0..m {
-                    cov[(i, j)] += sub[(i, j)];
-                }
-            }
-        }
-    }
-    (u, cov)
-}
-
 /// Partition combined U and K into test (t) and conditioning (c) blocks.
+#[allow(clippy::type_complexity)]
 fn partition_u_cov(
     u: &Mat<f64>,
     k: &Mat<f64>,

--- a/src/staar/pipeline.rs
+++ b/src/staar/pipeline.rs
@@ -33,7 +33,7 @@ use crate::types::{AnnotatedVariant, Chromosome};
 pub enum CohortSource {
     Existing,
     Fresh {
-        genotypes: PathBuf,
+        genotypes: Vec<PathBuf>,
         annotations: PathBuf,
     },
 }
@@ -63,9 +63,9 @@ pub struct StaarConfig {
 }
 
 impl StaarConfig {
-    pub fn genotypes(&self) -> Option<&Path> {
+    pub fn genotypes(&self) -> Option<&[PathBuf]> {
         match &self.cohort_source {
-            CohortSource::Fresh { genotypes, .. } => Some(genotypes.as_path()),
+            CohortSource::Fresh { genotypes, .. } => Some(genotypes.as_slice()),
             CohortSource::Existing => None,
         }
     }
@@ -128,15 +128,15 @@ impl StaarConfig {
         &'a self,
         existing_cohort_manifest: Option<&'a Path>,
     ) -> ConfigHashInputs<'a> {
-        let (genotypes, annotations): (&Path, &Path) = match &self.cohort_source {
+        let (genotypes, annotations): (Vec<PathBuf>, &Path) = match &self.cohort_source {
             CohortSource::Fresh {
                 genotypes,
                 annotations,
-            } => (genotypes, annotations),
+            } => (genotypes.clone(), annotations),
             CohortSource::Existing => {
                 let p = existing_cohort_manifest
                     .expect("existing cohort config hash requires a resolved manifest path");
-                (p, p)
+                (vec![p.to_path_buf()], p)
             }
         };
         ConfigHashInputs {
@@ -990,7 +990,7 @@ mod tests {
     fn dummy_config() -> StaarConfig {
         StaarConfig {
             cohort_source: CohortSource::Fresh {
-                genotypes: PathBuf::from("/tmp/g.vcf.gz"),
+                genotypes: vec![PathBuf::from("/tmp/g.vcf.gz")],
                 annotations: PathBuf::from("/tmp/a.annotated"),
             },
             phenotype: PathBuf::from("/tmp/p.tsv"),

--- a/src/staar/pipeline.rs
+++ b/src/staar/pipeline.rs
@@ -23,7 +23,7 @@ use crate::staar::scoring::{self, MultiScoringRequest, ResultSet, ScoringRequest
 use crate::staar::{
     self, ancestry::AncestryInfo, MaskCategory, NullModelKind, RunMode, ScoringMode, TraitType,
 };
-use crate::store::cache::score_cache;
+use crate::store::cache::{null_model_cache, score_cache};
 use crate::store::cohort::{
     self, CohortHandle, CohortId, CohortManifest, GenoStoreResult, STAAR_ANNOTATION_COLUMNS,
 };
@@ -607,23 +607,66 @@ impl<'a> StaarPipeline<'a> {
         pheno: &PhenoStageOut,
         store: &GenoStoreResult,
     ) -> Result<NullModel, CohortError> {
+        let has_kinship = self.config.has_kinship();
+
+        // Cache lookup (skip for kinship models — KinshipState contains
+        // sparse Cholesky factors that are not serializable in v1).
+        let cache_dir = if !has_kinship {
+            let key_str = null_model_cache::cache_key(
+                &store.manifest.key,
+                &self.config.trait_names[0],
+                &self.config.covariates,
+                self.config.known_loci.as_deref(),
+                &self.config.kinship,
+                self.config.kinship_groups.as_deref(),
+            );
+            let dir = self
+                .engine
+                .store()
+                .cache()
+                .null_model_cache_dir(
+                    &self.config.cohort_id,
+                    &crate::store::ids::CacheKey::new(&key_str),
+                );
+            if null_model_cache::probe(&dir) {
+                self.out.status("Null model cache: hit");
+                self.manifest.outputs.cache_decisions.push(CacheDecision {
+                    artifact: ArtifactKind::GenotypeStore,
+                    outcome: CacheOutcome::Hit,
+                    reason: "null model cache hit".into(),
+                });
+                let nm = null_model_cache::load(&dir)?;
+                self.out.status(&format!("  sigma2 = {:.4}", nm.sigma2));
+                return Ok(nm);
+            }
+            Some(dir)
+        } else {
+            self.out
+                .status("  Null model cache: skipped (kinship models not cached in v1)");
+            None
+        };
+
         self.out.status("Fitting null model...");
 
-        match self.config.null_model_kind(pheno.trait_type) {
-            NullModelKind::Glm => {
-                let nm = staar::model::fit_glm(&pheno.y, &pheno.x);
-                self.out.status(&format!("  sigma2 = {:.4}", nm.sigma2));
-                Ok(nm)
-            }
-            NullModelKind::Logistic => {
-                let nm = staar::model::fit_logistic(&pheno.y, &pheno.x, 25);
-                self.out.status(&format!("  sigma2 = {:.4}", nm.sigma2));
-                Ok(nm)
-            }
+        let nm = match self.config.null_model_kind(pheno.trait_type) {
+            NullModelKind::Glm => staar::model::fit_glm(&pheno.y, &pheno.x),
+            NullModelKind::Logistic => staar::model::fit_logistic(&pheno.y, &pheno.x, 25),
             kind @ (NullModelKind::KinshipReml | NullModelKind::KinshipPql) => {
-                self.fit_kinship_null_model(kind, pheno, store)
+                self.fit_kinship_null_model(kind, pheno, store)?
+            }
+        };
+        self.out.status(&format!("  sigma2 = {:.4}", nm.sigma2));
+
+        if let Some(ref dir) = cache_dir {
+            if let Err(e) = null_model_cache::save(dir, &nm) {
+                self.out
+                    .warn(&format!("  Null model cache: save failed ({e})"));
+            } else {
+                self.out.status("  Null model: fitted and cached");
             }
         }
+
+        Ok(nm)
     }
 
     /// Kinship-aware null model: load kinship matrices, build the group

--- a/src/staar/run_manifest.rs
+++ b/src/staar/run_manifest.rs
@@ -246,7 +246,7 @@ pub fn now_unix() -> u64 {
 /// Borrowed view of the `StaarConfig` fields that determine results.
 /// Lives here so the hashing logic doesn't have to import `StaarConfig`.
 pub struct ConfigHashInputs<'a> {
-    pub genotypes: &'a Path,
+    pub genotypes: Vec<PathBuf>,
     pub annotations: &'a Path,
     pub phenotype: &'a Path,
     pub trait_names: &'a [String],
@@ -263,7 +263,10 @@ pub struct ConfigHashInputs<'a> {
 pub fn compute_config_hash(inputs: &ConfigHashInputs<'_>) -> String {
     use sha2::{Digest, Sha256};
     let mut h = Sha256::new();
-    h.update(inputs.genotypes.to_string_lossy().as_bytes());
+    for g in &inputs.genotypes {
+        h.update(g.to_string_lossy().as_bytes());
+        h.update(b",");
+    }
     h.update(b"|");
     h.update(inputs.annotations.to_string_lossy().as_bytes());
     h.update(b"|");
@@ -557,7 +560,7 @@ mod tests {
         let covs = vec!["age".to_string(), "sex".to_string()];
         let kinship: Vec<PathBuf> = Vec::new();
         let inputs = ConfigHashInputs {
-            genotypes: Path::new("/tmp/g.vcf.gz"),
+            genotypes: vec![PathBuf::from("/tmp/g.vcf.gz")],
             annotations: Path::new("/tmp/a"),
             phenotype: Path::new("/tmp/p.tsv"),
             trait_names: &trait_names,
@@ -571,17 +574,14 @@ mod tests {
 
         let inputs2 = ConfigHashInputs {
             maf_cutoff: 0.05,
-            ..ConfigHashInputs {
-                genotypes: Path::new("/tmp/g.vcf.gz"),
-                annotations: Path::new("/tmp/a"),
-                phenotype: Path::new("/tmp/p.tsv"),
-                trait_names: &trait_names,
-                covariates: &covs,
-                maf_cutoff: 0.01,
-                run_mode: RunMode::Analyze,
-                kinship: &kinship,
-                kinship_groups: None,
-            }
+            genotypes: vec![PathBuf::from("/tmp/g.vcf.gz")],
+            annotations: Path::new("/tmp/a"),
+            phenotype: Path::new("/tmp/p.tsv"),
+            trait_names: &trait_names,
+            covariates: &covs,
+            run_mode: RunMode::Analyze,
+            kinship: &kinship,
+            kinship_groups: None,
         };
         let h2 = compute_config_hash(&inputs2);
         assert_ne!(h1, h2);
@@ -590,17 +590,14 @@ mod tests {
         let covs_reversed = vec!["sex".to_string(), "age".to_string()];
         let inputs3 = ConfigHashInputs {
             covariates: &covs_reversed,
-            ..ConfigHashInputs {
-                genotypes: Path::new("/tmp/g.vcf.gz"),
-                annotations: Path::new("/tmp/a"),
-                phenotype: Path::new("/tmp/p.tsv"),
-                trait_names: &trait_names,
-                covariates: &covs,
-                maf_cutoff: 0.01,
-                run_mode: RunMode::Analyze,
-                kinship: &kinship,
-                kinship_groups: None,
-            }
+            genotypes: vec![PathBuf::from("/tmp/g.vcf.gz")],
+            annotations: Path::new("/tmp/a"),
+            phenotype: Path::new("/tmp/p.tsv"),
+            trait_names: &trait_names,
+            maf_cutoff: 0.01,
+            run_mode: RunMode::Analyze,
+            kinship: &kinship,
+            kinship_groups: None,
         };
         assert_eq!(h1, compute_config_hash(&inputs3));
     }

--- a/src/store/cache/mod.rs
+++ b/src/store/cache/mod.rs
@@ -1,5 +1,6 @@
 //! Derived caches keyed by cohort id. Today: per-phenotype score cache.
 
+pub mod null_model_cache;
 pub mod score_cache;
 
 use std::path::PathBuf;
@@ -23,22 +24,26 @@ impl<'a> CacheStore<'a> {
         self.layout.score_cache_dir(cohort, key)
     }
 
+    pub fn null_model_cache_dir(&self, cohort: &CohortId, key: &CacheKey) -> PathBuf {
+        self.layout.null_model_cache_dir(cohort, key)
+    }
+
     /// Delete the score-cache directory owned by `cohort`. Called when
     /// `--rebuild-store` flips the content fingerprint and the existing
     /// cache no longer matches.
     pub fn prune_cohort(&self, cohort: &CohortId) -> Result<PruneSummary, CohortError> {
         let mut summary = PruneSummary::default();
-        for sub in ["score_cache", "lookups"] {
+        for sub in ["score_cache", "lookups", "null_model"] {
             let dir = self.layout.cache_root().join(sub).join(cohort.as_str());
             if dir.is_dir() {
                 summary.bytes_freed += dir_size(&dir);
                 std::fs::remove_dir_all(&dir).map_err(|e| {
                     CohortError::Resource(format!("rm {}: {e}", dir.display()))
                 })?;
-                if sub == "score_cache" {
-                    summary.removed_score_caches += 1;
-                } else {
-                    summary.removed_lookup_indexes += 1;
+                match sub {
+                    "score_cache" => summary.removed_score_caches += 1,
+                    "null_model" => summary.removed_null_models += 1,
+                    _ => summary.removed_lookup_indexes += 1,
                 }
             }
         }
@@ -51,7 +56,7 @@ impl<'a> CacheStore<'a> {
         let mut summary = PruneSummary::default();
         let alive: std::collections::HashSet<&str> =
             live.iter().map(|c| c.as_str()).collect();
-        for sub in ["score_cache", "lookups"] {
+        for sub in ["score_cache", "lookups", "null_model"] {
             let parent = self.layout.cache_root().join(sub);
             if !parent.is_dir() {
                 continue;
@@ -77,10 +82,10 @@ impl<'a> CacheStore<'a> {
                 std::fs::remove_dir_all(&p).map_err(|e| {
                     CohortError::Resource(format!("rm {}: {e}", p.display()))
                 })?;
-                if sub == "score_cache" {
-                    summary.removed_score_caches += 1;
-                } else {
-                    summary.removed_lookup_indexes += 1;
+                match sub {
+                    "score_cache" => summary.removed_score_caches += 1,
+                    "null_model" => summary.removed_null_models += 1,
+                    _ => summary.removed_lookup_indexes += 1,
                 }
             }
         }
@@ -92,6 +97,7 @@ impl<'a> CacheStore<'a> {
 pub struct PruneSummary {
     pub removed_score_caches: usize,
     pub removed_lookup_indexes: usize,
+    pub removed_null_models: usize,
     pub bytes_freed: u64,
 }
 

--- a/src/store/cache/null_model_cache.rs
+++ b/src/store/cache/null_model_cache.rs
@@ -1,0 +1,350 @@
+//! Null model disk cache: persist fitted NullModel so re-runs with the
+//! same cohort/trait/covariates skip the fitting step.
+//!
+//! Disk format (`null_model.bin`):
+//!   Header (64 bytes): magic, version, n_samples, n_covariates, sigma2, flags
+//!   Body: residuals[n], x_matrix[n*k], xtx_inv[k*k] as raw f64 LE
+//!   If has_fitted: fitted_values[n]
+//!   If has_working_weights: working_weights[n]
+//!
+//! Kinship-aware models are NOT cached in v1 — the KinshipState contains a
+//! sparse Cholesky factor that is not trivially serializable. A warning is
+//! logged and the null model is refit.
+
+use std::io::{Read as IoRead, Write as IoWrite};
+use std::path::{Path, PathBuf};
+
+use faer::Mat;
+use sha2::{Digest, Sha256};
+
+use crate::error::CohortError;
+use crate::staar::model::NullModel;
+
+const MAGIC: &[u8; 8] = b"FVNULLM1";
+const VERSION: u16 = 1;
+const HEADER_SIZE: usize = 64;
+
+const FLAG_HAS_FITTED: u8 = 1;
+const FLAG_HAS_WORKING_WEIGHTS: u8 = 2;
+
+/// Cache key for the null model, following the same hashing pattern as
+/// `score_cache::cache_key`. Keyed by (store manifest key, trait, sorted
+/// covariates, known-loci content, kinship paths, kinship groups).
+pub fn cache_key(
+    store_key: &str,
+    trait_name: &str,
+    covariates: &[String],
+    known_loci: Option<&Path>,
+    kinship: &[PathBuf],
+    kinship_groups: Option<&str>,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"null_model|");
+    hasher.update(store_key.as_bytes());
+    hasher.update(b"|");
+    hasher.update(trait_name.as_bytes());
+    hasher.update(b"|");
+    let mut sorted = covariates.to_vec();
+    sorted.sort();
+    for cov in &sorted {
+        hasher.update(cov.as_bytes());
+        hasher.update(b",");
+    }
+    hasher.update(b"|");
+    if let Some(p) = known_loci {
+        hasher.update(b"loci=");
+        match std::fs::read(p) {
+            Ok(bytes) => hasher.update(&bytes),
+            Err(_) => hasher.update(p.to_string_lossy().as_bytes()),
+        }
+    }
+    hasher.update(b"|");
+    let mut canonical: Vec<String> = kinship
+        .iter()
+        .map(|p| {
+            std::fs::canonicalize(p)
+                .map(|c| c.to_string_lossy().into_owned())
+                .unwrap_or_else(|_| p.to_string_lossy().into_owned())
+        })
+        .collect();
+    canonical.sort();
+    for c in &canonical {
+        hasher.update(c.as_bytes());
+        hasher.update(b",");
+    }
+    hasher.update(b"|");
+    if let Some(g) = kinship_groups {
+        hasher.update(g.as_bytes());
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+/// Check whether a cached null model exists and has a valid header.
+pub fn probe(dir: &Path) -> bool {
+    let path = dir.join("null_model.bin");
+    let Ok(meta) = std::fs::metadata(&path) else {
+        return false;
+    };
+    if meta.len() < HEADER_SIZE as u64 {
+        return false;
+    }
+    let Ok(mut f) = std::fs::File::open(&path) else {
+        return false;
+    };
+    let mut header = [0u8; HEADER_SIZE];
+    if f.read_exact(&mut header).is_err() {
+        return false;
+    }
+    &header[0..8] == MAGIC && u16::from_le_bytes([header[8], header[9]]) == VERSION
+}
+
+/// Serialize a NullModel to disk. Atomic: writes .tmp then renames.
+pub fn save(dir: &Path, model: &NullModel) -> Result<(), CohortError> {
+    std::fs::create_dir_all(dir)
+        .map_err(|e| CohortError::Resource(format!("create {}: {e}", dir.display())))?;
+
+    let path = dir.join("null_model.bin");
+    let tmp = dir.join("null_model.bin.tmp");
+
+    let n = model.n_samples;
+    let k = model.x_matrix.ncols();
+    let mut flags: u8 = 0;
+    if model.fitted_values.is_some() {
+        flags |= FLAG_HAS_FITTED;
+    }
+    if model.working_weights.is_some() {
+        flags |= FLAG_HAS_WORKING_WEIGHTS;
+    }
+
+    let mut w = std::io::BufWriter::new(
+        std::fs::File::create(&tmp)
+            .map_err(|e| CohortError::Resource(format!("create {}: {e}", tmp.display())))?,
+    );
+
+    // Header
+    let mut header = [0u8; HEADER_SIZE];
+    header[0..8].copy_from_slice(MAGIC);
+    header[8..10].copy_from_slice(&VERSION.to_le_bytes());
+    header[10..14].copy_from_slice(&(n as u32).to_le_bytes());
+    header[14..18].copy_from_slice(&(k as u32).to_le_bytes());
+    header[18..26].copy_from_slice(&model.sigma2.to_le_bytes());
+    header[26] = flags;
+    w.write_all(&header)
+        .map_err(|e| CohortError::Resource(format!("write header: {e}")))?;
+
+    // residuals: n × 1 column-major (faer stores column-major)
+    write_mat(&mut w, &model.residuals)?;
+    // x_matrix: n × k
+    write_mat(&mut w, &model.x_matrix)?;
+    // xtx_inv: k × k
+    write_mat(&mut w, &model.xtx_inv)?;
+
+    if let Some(ref fv) = model.fitted_values {
+        write_vec(&mut w, fv)?;
+    }
+    if let Some(ref ww) = model.working_weights {
+        write_vec(&mut w, ww)?;
+    }
+
+    w.flush()
+        .map_err(|e| CohortError::Resource(format!("flush: {e}")))?;
+    drop(w);
+
+    // fsync + rename for atomicity
+    #[cfg(unix)]
+    {
+        use std::os::unix::io::AsRawFd;
+        let f = std::fs::File::open(&tmp)
+            .map_err(|e| CohortError::Resource(format!("reopen for fsync: {e}")))?;
+        unsafe { libc::fsync(f.as_raw_fd()) };
+    }
+
+    std::fs::rename(&tmp, &path)
+        .map_err(|e| CohortError::Resource(format!("rename {}: {e}", tmp.display())))?;
+
+    Ok(())
+}
+
+/// Deserialize a NullModel from disk.
+pub fn load(dir: &Path) -> Result<NullModel, CohortError> {
+    let path = dir.join("null_model.bin");
+    let mut f = std::io::BufReader::new(
+        std::fs::File::open(&path)
+            .map_err(|e| CohortError::DataMissing(format!("open {}: {e}", path.display())))?,
+    );
+
+    let mut header = [0u8; HEADER_SIZE];
+    f.read_exact(&mut header)
+        .map_err(|e| CohortError::DataMissing(format!("read header: {e}")))?;
+
+    if &header[0..8] != MAGIC {
+        return Err(CohortError::DataMissing(format!(
+            "{}: bad magic",
+            path.display()
+        )));
+    }
+    let version = u16::from_le_bytes([header[8], header[9]]);
+    if version != VERSION {
+        return Err(CohortError::DataMissing(format!(
+            "{}: version {version}, expected {VERSION}",
+            path.display()
+        )));
+    }
+
+    let n = u32::from_le_bytes(header[10..14].try_into().unwrap()) as usize;
+    let k = u32::from_le_bytes(header[14..18].try_into().unwrap()) as usize;
+    let sigma2 = f64::from_le_bytes(header[18..26].try_into().unwrap());
+    let flags = header[26];
+
+    let residuals = read_mat(&mut f, n, 1)?;
+    let x_matrix = read_mat(&mut f, n, k)?;
+    let xtx_inv = read_mat(&mut f, k, k)?;
+
+    let fitted_values = if flags & FLAG_HAS_FITTED != 0 {
+        Some(read_vec(&mut f, n)?)
+    } else {
+        None
+    };
+
+    let working_weights = if flags & FLAG_HAS_WORKING_WEIGHTS != 0 {
+        Some(read_vec(&mut f, n)?)
+    } else {
+        None
+    };
+
+    Ok(NullModel {
+        residuals,
+        x_matrix,
+        xtx_inv,
+        sigma2,
+        n_samples: n,
+        fitted_values,
+        working_weights,
+        kinship: None,
+    })
+}
+
+fn write_mat(w: &mut impl IoWrite, m: &Mat<f64>) -> Result<(), CohortError> {
+    for j in 0..m.ncols() {
+        for i in 0..m.nrows() {
+            w.write_all(&m[(i, j)].to_le_bytes())
+                .map_err(|e| CohortError::Resource(format!("write mat: {e}")))?;
+        }
+    }
+    Ok(())
+}
+
+fn write_vec(w: &mut impl IoWrite, v: &[f64]) -> Result<(), CohortError> {
+    for val in v {
+        w.write_all(&val.to_le_bytes())
+            .map_err(|e| CohortError::Resource(format!("write vec: {e}")))?;
+    }
+    Ok(())
+}
+
+fn read_mat(r: &mut impl IoRead, nrows: usize, ncols: usize) -> Result<Mat<f64>, CohortError> {
+    let mut m = Mat::zeros(nrows, ncols);
+    let mut buf = [0u8; 8];
+    for j in 0..ncols {
+        for i in 0..nrows {
+            r.read_exact(&mut buf)
+                .map_err(|e| CohortError::DataMissing(format!("read mat: {e}")))?;
+            m[(i, j)] = f64::from_le_bytes(buf);
+        }
+    }
+    Ok(m)
+}
+
+fn read_vec(r: &mut impl IoRead, n: usize) -> Result<Vec<f64>, CohortError> {
+    let mut v = Vec::with_capacity(n);
+    let mut buf = [0u8; 8];
+    for _ in 0..n {
+        r.read_exact(&mut buf)
+            .map_err(|e| CohortError::DataMissing(format!("read vec: {e}")))?;
+        v.push(f64::from_le_bytes(buf));
+    }
+    Ok(v)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dummy_model(n: usize, k: usize) -> NullModel {
+        let mut residuals = Mat::zeros(n, 1);
+        for i in 0..n {
+            residuals[(i, 0)] = (i as f64) * 0.1;
+        }
+        let mut x = Mat::zeros(n, k);
+        for i in 0..n {
+            for j in 0..k {
+                x[(i, j)] = (i * k + j) as f64;
+            }
+        }
+        let xtx_inv = Mat::identity(k, k);
+        NullModel {
+            residuals,
+            x_matrix: x,
+            xtx_inv,
+            sigma2: 1.234,
+            n_samples: n,
+            fitted_values: None,
+            working_weights: None,
+            kinship: None,
+        }
+    }
+
+    #[test]
+    fn round_trip_continuous() {
+        let dir = tempfile::tempdir().unwrap();
+        let model = dummy_model(100, 3);
+        save(dir.path(), &model).unwrap();
+        assert!(probe(dir.path()));
+
+        let loaded = load(dir.path()).unwrap();
+        assert_eq!(loaded.n_samples, 100);
+        assert_eq!(loaded.x_matrix.ncols(), 3);
+        assert!((loaded.sigma2 - 1.234).abs() < 1e-12);
+        assert!(loaded.fitted_values.is_none());
+        assert!(loaded.working_weights.is_none());
+        assert!(loaded.kinship.is_none());
+
+        for i in 0..100 {
+            assert!((loaded.residuals[(i, 0)] - (i as f64) * 0.1).abs() < 1e-12);
+        }
+    }
+
+    #[test]
+    fn round_trip_binary() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut model = dummy_model(50, 2);
+        model.fitted_values = Some(vec![0.5; 50]);
+        model.working_weights = Some(vec![0.25; 50]);
+        save(dir.path(), &model).unwrap();
+
+        let loaded = load(dir.path()).unwrap();
+        assert_eq!(loaded.fitted_values.as_ref().unwrap().len(), 50);
+        assert_eq!(loaded.working_weights.as_ref().unwrap().len(), 50);
+        assert!((loaded.fitted_values.unwrap()[0] - 0.5).abs() < 1e-12);
+    }
+
+    #[test]
+    fn probe_missing_returns_false() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!probe(dir.path()));
+    }
+
+    #[test]
+    fn cache_key_differs_by_trait() {
+        let k1 = cache_key("store", "BMI", &[], None, &[], None);
+        let k2 = cache_key("store", "HEIGHT", &[], None, &[], None);
+        assert_ne!(k1, k2);
+    }
+
+    #[test]
+    fn cache_key_covariate_order_irrelevant() {
+        let k1 = cache_key("s", "t", &["age".into(), "sex".into()], None, &[], None);
+        let k2 = cache_key("s", "t", &["sex".into(), "age".into()], None, &[], None);
+        assert_eq!(k1, k2);
+    }
+}

--- a/src/store/cohort/handle.rs
+++ b/src/store/cohort/handle.rs
@@ -25,7 +25,7 @@ use super::{
 };
 
 pub struct CohortSources<'a> {
-    pub genotypes: &'a Path,
+    pub genotypes: &'a [PathBuf],
     pub annotations: &'a Path,
 }
 
@@ -72,7 +72,7 @@ impl<'a> CohortHandle<'a> {
 
     /// Probe + (re)build path for the cohort. Wraps the existing free
     /// functions so the pipeline never reaches into raw `cohort::probe`.
-    pub fn probe(&self, genotypes: &std::path::Path, annotations: &std::path::Path) -> StoreProbe {
+    pub fn probe(&self, genotypes: &[PathBuf], annotations: &std::path::Path) -> StoreProbe {
         cohort_probe(&self.dir, genotypes, annotations)
     }
 
@@ -181,7 +181,10 @@ impl<'a> CohortHandle<'a> {
         out.status(&why);
         out.status("Building genotype store...");
 
-        out.status("  Extracting genotypes from VCF...");
+        out.status(&format!(
+            "  Extracting genotypes from {} VCF file(s)...",
+            genotypes.len()
+        ));
         let geno = crate::staar::genotype::extract_genotypes(
             genotypes,
             staging_dir,
@@ -213,9 +216,9 @@ impl<'a> CohortHandle<'a> {
 
         if n_all == 0 {
             return Err(CohortError::Analysis(format!(
-                "No variants found after joining genotypes ({}) with annotations ({}). \
+                "No variants found after joining genotypes ({} file(s)) with annotations ({}). \
                  Check that both use the same genome build and allele normalization.",
-                genotypes.display(),
+                genotypes.len(),
                 annotations.display(),
             )));
         }

--- a/src/store/cohort/mod.rs
+++ b/src/store/cohort/mod.rs
@@ -96,15 +96,17 @@ fn dir_fingerprint(path: &Path) -> Result<Vec<u8>, CohortError> {
     Ok(hasher.finalize().to_vec())
 }
 
-pub fn compute_key(vcf_path: &Path, annotations_path: &Path) -> Result<String, CohortError> {
-    let vcf_fp = file_content_fingerprint(vcf_path)?;
+pub fn compute_key(vcf_paths: &[PathBuf], annotations_path: &Path) -> Result<String, CohortError> {
+    let mut hasher = Sha256::new();
+    for vcf_path in vcf_paths {
+        let vcf_fp = file_content_fingerprint(vcf_path)?;
+        hasher.update(&vcf_fp);
+    }
     let ann_fp = if annotations_path.is_dir() {
         dir_fingerprint(annotations_path)?
     } else {
         file_content_fingerprint(annotations_path)?
     };
-    let mut hasher = Sha256::new();
-    hasher.update(&vcf_fp);
     hasher.update(&ann_fp);
     Ok(format!("{:x}", hasher.finalize()))
 }
@@ -126,7 +128,7 @@ pub struct StoreProbe {
     pub miss_reason: Option<ProbeReason>,
 }
 
-pub fn probe(store_dir: &Path, vcf_path: &Path, annotations_path: &Path) -> StoreProbe {
+pub fn probe(store_dir: &Path, vcf_paths: &[PathBuf], annotations_path: &Path) -> StoreProbe {
     let store_dir = store_dir.to_path_buf();
     let miss = |reason: ProbeReason| StoreProbe {
         store_dir: store_dir.clone(),
@@ -144,7 +146,7 @@ pub fn probe(store_dir: &Path, vcf_path: &Path, annotations_path: &Path) -> Stor
     let Ok(manifest) = serde_json::from_str::<CohortManifest>(&s) else {
         return miss(ProbeReason::UnreadableManifest);
     };
-    let Ok(key) = compute_key(vcf_path, annotations_path) else {
+    let Ok(key) = compute_key(vcf_paths, annotations_path) else {
         return miss(ProbeReason::FingerprintFailed);
     };
 
@@ -316,7 +318,7 @@ pub fn build(
     engine: &DfEngine,
     geno_result: &crate::staar::genotype::GenotypeResult,
     store_dir: &Path,
-    vcf_path: &Path,
+    vcf_paths: &[PathBuf],
     annotations_path: &Path,
     out: &dyn Output,
 ) -> Result<CohortManifest, CohortError> {
@@ -331,7 +333,7 @@ pub fn build(
     // next to staging so it survives the rename of `store_dir`.
     let _lock = BuildLock::acquire(&staging.with_extension("lock"))?;
 
-    let key = compute_key(vcf_path, annotations_path)?;
+    let key = compute_key(vcf_paths, annotations_path)?;
     let n_samples = geno_result.sample_names.len();
 
     let samples_path = staging.join("samples.txt");
@@ -545,7 +547,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let bogus_vcf = dir.path().join("does-not-exist.vcf.gz");
         let bogus_ann = dir.path().join("does-not-exist.annotated");
-        let p = probe(dir.path(), &bogus_vcf, &bogus_ann);
+        let p = probe(dir.path(), &[bogus_vcf], &bogus_ann);
         assert!(p.manifest.is_none());
         assert_eq!(p.miss_reason, Some(ProbeReason::NoManifest));
     }
@@ -556,7 +558,7 @@ mod tests {
         std::fs::write(dir.path().join("manifest.json"), "{ not valid json").unwrap();
         let bogus_vcf = dir.path().join("does-not-exist.vcf.gz");
         let bogus_ann = dir.path().join("does-not-exist.annotated");
-        let p = probe(dir.path(), &bogus_vcf, &bogus_ann);
+        let p = probe(dir.path(), &[bogus_vcf], &bogus_ann);
         assert!(p.manifest.is_none());
         assert_eq!(p.miss_reason, Some(ProbeReason::UnreadableManifest));
     }

--- a/src/store/layout.rs
+++ b/src/store/layout.rs
@@ -46,6 +46,13 @@ impl Layout {
             .join(key.as_str())
     }
 
+    pub fn null_model_cache_dir(&self, cohort: &CohortId, key: &CacheKey) -> PathBuf {
+        self.cache_root()
+            .join("null_model")
+            .join(cohort.as_str())
+            .join(key.as_str())
+    }
+
     /// Subdirectories that `Store::open` materializes lazily.
     pub(super) fn known_subdirs(&self) -> [PathBuf; 4] {
         [


### PR DESCRIPTION
## Summary

- multi-VCF `--genotypes` and single-pass ingest (#4, #70)
- persist null model to disk for multi-trait reuse (#23)
- enrichment: skip chromosomes with no query variants (#31)
- conditional MetaSTAAR with homogeneous and heterogeneous effects (#11)
- fix conditional MetaSTAAR: reject heterogeneous, fix format string
- readme updates

## Closes

Closes #4
Closes #70
Closes #23
Closes #31
Closes #11

269 tests, zero clippy warnings.