### PR TITLE
docs: STAAR + ingest reference pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ TMPDIR                 scratch space
 ## Docs
 
 - **[Setup guide](docs/setup.md)** - installation, configuration, data management, HPC best practices
+- [Ingest](docs/ingest.md) - VCF ingest patterns, preflight, throughput
 - [Genotype store](docs/storage.md) - sparse genotype store for rare-variant analysis
 - [STAAR](docs/staar.md) - null model, score test, masks, outputs, meta-analysis
 - [Validation](docs/validation.md) - statistical accuracy vs R reference

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ TMPDIR                 scratch space
 
 - **[Setup guide](docs/setup.md)** - installation, configuration, data management, HPC best practices
 - [Genotype store](docs/storage.md) - sparse genotype store for rare-variant analysis
+- [STAAR](docs/staar.md) - null model, score test, masks, outputs, meta-analysis
 - [Validation](docs/validation.md) - statistical accuracy vs R reference
 - [Statistical divergences](docs/statistical-divergences.md) - known differences from R STAAR/SKAT and why
 - [Performance](docs/performance.md) - benchmarks and optimization roadmap

--- a/docs/ingest.md
+++ b/docs/ingest.md
@@ -1,0 +1,143 @@
+# Ingest
+
+Streams VCF (plain or BGZF) into columnar parquet. For multi-sample VCFs
+(biobank dosages) it also writes the sparse genotype store the downstream
+STAAR path needs.
+
+```text
+  *.vcf / *.vcf.gz
+         │
+         │  streaming parse (noodles-vcf) + memchr tab split
+         ▼
+  +----------------------+       variants.parquet    (columnar, per-chr)
+  |  parallel ingest     │──┬──► membership.parquet  (gene ↔ variant_vcf)
+  |  (rayon)             │  │
+  +----------------------+  └──► sparse_g.bin        (carrier list, mmap-ready)
+```
+
+Genotypes stay dense in memory only long enough to identify non-zero
+carriers. See [Genotype store](storage.md) for the on-disk shape.
+
+> [Back to README](../README.md) · [Genotype store](storage.md) · [STAAR](staar.md)
+
+## Data Shapes
+
+```text
+INPUT                              TRANSFORMATION              OUTPUT
+──────────────────────────         ──────────────────────      ──────────────────────────
+path(s) to *.vcf[.gz]         ─┐                               variants.parquet  (per chr)
+  samples in columns           ├─ parse + normalize            membership.parquet
+  variants in rows             │  split multi-allelic          sparse_g.bin      (if genotypes)
+                               │  parsimony (ref, alt)          samples.txt       (sidecar)
+annotated variant set         ─┤  left-join on (chr, pos,      genotypes.json    (sidecar)
+  (from favor annotate)        │  ref, alt)
+                               └─ carrier-only genotype cast
+```
+
+## Running It
+
+### Workstation (single box, many cores)
+
+One command, all files. Let rayon saturate cores:
+
+```bash
+favor ingest --annotations variants.annotated/ \
+  data/ukb23157_c1_b1.vcf.gz data/ukb23157_c1_b2.vcf.gz ...
+```
+
+Threads and memory are auto-detected from cgroup + SLURM; override with
+`--threads` / `SLURM_MEM_PER_NODE` if needed. Files are chunked across
+workers; each worker processes its chunk sequentially with one
+`RecordContext`.
+
+### HPC (per-chromosome SLURM jobs)
+
+One job per chromosome. Each job uses the full node's cores for its
+chromosome's files. Good when the cluster is bursty and a single
+multi-chromosome job would starve:
+
+```bash
+# submit.sh
+for chr in {1..22} X Y; do
+  srun -p xlin -t 0-04:00 --mem=64G -c 16 -J "ingest_chr${chr}" \
+    favor ingest --annotations variants.annotated/ \
+      data/ukb23157_c${chr}_b*.vcf.gz &
+done
+wait
+```
+
+The parallel ingest path does not split a single file across workers —
+block-level parallelism is the next milestone. If your files span one
+chromosome each, the per-file parallel ingest already does the right
+thing on a single node.
+
+### File ordering
+
+The chunker interleaves files round-robin across workers
+(`files[w], files[w + N], files[w + 2N], …`). For multi-chromosome inputs
+this spreads chromosomes across workers — fine for even load, but each
+worker pays a ~100 ms writer-switch cost per chromosome change. If all
+files for a chromosome live in a contiguous span of `--input` args, the
+round-robin still works; if mixed, sort by chromosome first.
+
+## Preflight
+
+Before any worker starts, `ingest_vcfs_parallel` runs four cheap checks.
+Each fails fast with a typed error.
+
+```text
+check                       why                                            behavior
+──────────────────────      ──────────────────────────────────────────     ──────────────────
+duplicate inputs            canonicalize paths; passing the same file      errors (exit 1)
+                            twice double-counts carriers
+stale part files            a previous run that died mid-way leaves        removes them
+                            part_*.parquet under chromosome=*/; picking
+                            both up corrupts variant counts
+fd soft limit               each worker opens ~24 chrom writers + bgzf     caps --threads
+                            reader + geno writer; default ulimit is 1024
+batch-size viability        row-group must clear 500 variants or the       caps --threads, or
+                            writer flushes per variant                      errors (exit 3)
+```
+
+Preflight messages are prefixed with `  Preflight:` in human mode. In
+machine mode (`--format json`) they surface as structured status lines.
+
+## Throughput Tips
+
+```text
+bottleneck                   fix                                            where it lives
+──────────────────────       ──────────────────────────────────────         ──────────────────
+bgzf decompression           more BGZF worker threads (auto-scales          noodles-bgzf
+                             with `--threads`)                               reader::Builder
+VCF line scan                SIMD tab search via memchr AVX2/SSE4.2         memchr_iter in
+                             (already enabled; no tuning)                    GenotypeWriter
+sample-column parse          SIMD tab find, then gt_prefix_len on
+                             each GT block
+row-group churn              raise per-worker memory so raw_batch_size      MIN_VIABLE_BATCH
+                             clears 500; preflight will cap workers          in preflight
+                             if too tight
+fd exhaustion                `ulimit -n 4096` on the shell before ingest    fd soft limit
+                             (preflight will cap otherwise)
+```
+
+For a 200K-sample exome chr22 on 16 cores and 64 GB the warm path sits
+in the 10–15 minute range. The hot cost is BGZF decompression + sample
+column parse — both SIMD already.
+
+## Machine Mode
+
+`--format json` emits one line per status event plus a final JSON
+summary. Orchestrators consume this without parsing human text:
+
+```bash
+favor ingest --format json ... | jq 'select(.event == "variant_count")'
+```
+
+`--dry-run` validates inputs (preflight runs) and prints the derived
+plan without opening writers.
+
+## Related
+
+- [Genotype store](storage.md) — on-disk shape of `sparse_g.bin`, `variants.parquet`, `membership.parquet`
+- [STAAR](staar.md) — the consumer of what ingest produces
+- [Performance](performance.md) — memory pool, hot paths

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -2,7 +2,7 @@
 
 Where time and memory go in COHORT today.
 
-> [Back to README](../README.md) · [Genotype Store](storage.md)
+> [Back to README](../README.md) · [Genotype Store](storage.md) · [STAAR](staar.md)
 
 ## Hot Paths
 

--- a/docs/staar.md
+++ b/docs/staar.md
@@ -1,0 +1,283 @@
+# STAAR
+
+Takes a fitted null model and a sparse genotype slice, runs a score-test
+battery per gene or window, writes per-mask parquet results.
+
+```text
+  phenotype + covariates (+ kinship if related samples)
+              │
+              │  fit null model   (expensive, once per trait)
+              ▼
+        null model
+        ├─ residuals  r     what the covariates don't explain in y
+        └─ projection P̂    how to measure a genotype's effect under the null
+              │
+              │  +  sparse genotype store (from favor ingest)
+              │
+              │  score test      (cheap, once per gene × mask)
+              ▼
+        per-gene parquet results
+```
+
+Fit the null once. Reuse it for thousands of gene × mask score tests.
+Genotypes only enter at the score step.
+
+> [Back to README](../README.md) · [Genotype store](storage.md) · [Validation](validation.md) · [Divergences](statistical-divergences.md)
+
+## How The Pieces Tie Together
+
+Three independent choices, picked once per run. They compose:
+
+```text
+null model kind       ×   score mode        ×   masks
+───────────────           ──────────            ──────────────
+Glm           (no K)      Standard              coding
+Logistic      (no K)      Spa       (binary)    noncoding
+KinshipReml   (with K)    AiStaar   (ancestry)  sliding-window
+KinshipPql    (with K)                          scang
+```
+
+- **null model kind** — trait numeric or yes/no × samples unrelated or related.
+- **score mode** — how to turn `U` into a p-value.
+- **masks** — which variants enter each test.
+
+## Pipeline Stages
+
+`src/staar/pipeline.rs`. One resumable `run.json` tracks each stage.
+
+```text
+Validate          check annotation schema, 11 STAAR weight channels
+EnsureStore       probe / build / load sparse genotype store
+LoadPhenotype     read pheno.tsv, align to samples.txt, infer trait type
+FitNullModel      dispatch on kind → r, P̂ pieces + disk cache
+EmitSumstats      (RunMode=EmitSumstats) write U/K segments, early exit
+EnsureScoreCache  fill chrom-wide U vector + per-gene K blocks
+RunScoring        per chromosome × gene × mask → StaarResult
+WriteResults      per-mask parquet + staar.meta.json
+```
+
+## Null Model Fit
+
+```text
+INPUT                      TRANSFORMATION                 OUTPUT
+────────────────────       ─────────────────────────      ───────────────────
+y    (n,)         ─┐                                       r     (n,)     residuals
+X    (n, p+1)     ─┼─ fit (OLS / IRLS / REML / PQL) ───►   P̂    pieces   tuning for score test
+K    (n, n) opt   ─┘                                       h²    scalar   heritability (if K)
+```
+
+`y` = phenotype per sample. `X` = intercept column + covariates. `K` =
+kinship matrix when samples are related.
+
+Worked example (fake LDL). Left = input, middle = what fit does, right = output `r`:
+
+```text
+sample age sex  LDL         fit finds Ŷ = f(age, sex)      r
+──────── ─── ── ────        ──────────────────────────     ───
+  0     45  M   130         expected 125 ··················+5
+  1     32  F    90         expected  95 ··················-5
+  2     61  M   165         expected 140 ··················+25
+  3     29  F   105         expected 100 ··················+5
+  4     54  M   148         expected 135 ··················+13
+```
+
+Genotypes never enter. `r` is the only per-sample output the score test reads.
+
+Which fitter runs:
+
+```text
+trait numeric?   samples related?   fitter         under-the-hood
+──────────────   ──────────────     ───────────    ─────────────────────
+yes              no                 Glm            OLS via QR
+yes              yes (kinship)      KinshipReml    REML, sparse Cholesky
+yes/no           no                 Logistic       IRLS logistic
+yes/no           yes (kinship)      KinshipPql     penalized quasi-likelihood
+```
+
+### Speed
+
+Linear algebra runs on [`faer`](https://github.com/sarah-quinones/faer-rs),
+a SIMD-vectorized BLAS-style backend. IRLS converges in a handful of
+iterations on exome-scale cohorts. Kinship fits use sparse Cholesky
+(`faer::sparse::Llt`) when `K` is block-diagonal, Hutchinson stochastic
+trace for log-det, and Takahashi's formula for the partial inverse the
+score test needs. `Glm` / `Logistic` fits cache to disk keyed by hash of
+(phenotype, covariates, kinship). Kinship fits don't cache in v0.2.
+
+## Score Test
+
+```text
+INPUT                         TRANSFORMATION              OUTPUT
+────────────                  ───────────────────         ──────────────────
+r     (n,)       from null  ─┐                            U    (m,)      signal
+G_S   (n, m)     mask slice  ├─ U = G_Sᵀ r ────────►      K    (m, m)   noise floor
+P̂   pieces      from null  ─┤  K = G_Sᵀ P̂ G_S ────►
+w     (11, m)    annot wts   ─┘  → 3 × 2 × 11 tests       66 weighted p-values
+                                 → Cauchy combine          STAAR-O (1 per gene)
+```
+
+Reading `U`, `K`: think signal and noise. `U[v]` = how much variant `v`
+lines up with the residuals. Big `|U|` = suspicious. `K` = how much `U`
+could wiggle by chance given the covariates already used.
+
+### Test battery
+
+Three test shapes × two β-weight shapes = six base tests. Each runs against
+eleven annotation channels = sixty-six weighted tests. All Cauchy-combined
+into `STAAR-O`.
+
+```text
+test      asks                                         good at
+────────  ────────────────────────────────────────     ──────────────────────
+Burden    do carriers shift the trait one direction?   all variants push same way
+SKAT      is there more spread than chance?            mix of protective & harmful
+ACAT-V    does any single variant stand out?           one bad actor in the set
+```
+
+### Score modes
+
+```text
+mode       when                                         what it changes
+─────────  ──────────────────────────────────────       ──────────────────────────
+Standard   default                                       reads cached U / K
+Spa        rare binary trait, heavy case imbalance       saddlepoint p-value tails
+AiStaar    ancestry-mixed cohort                         per-ancestry MAFs, ensemble
+```
+
+### Speed
+
+`U = G_Sᵀ r` on sparse carrier lists is `O(total MAC)`, not `O(n × m)`.
+For 200K samples and MAC = 5 per variant, that is a ~40,000× win over
+dense. `K` blocks run through `faer` (SIMD). Chromosome-wide `U` and
+per-gene `K` blocks are precomputed once into a score cache — rerunning
+with a different mask reslices existing blocks instead of recomputing.
+`rayon` parallelizes across genes within a chromosome.
+
+## Masks
+
+A mask is a predicate over annotated variants.
+
+```text
+INPUT                       TRANSFORMATION              OUTPUT
+──────────────────────      ─────────────────────       ──────────────────
+variants.parquet  ─┐        for each variant v:         variant_vcf list
+  (gene's variants) ├──►    pred(v) AND maf(v) < cut ─► (feeds G_S slice)
+mask predicate    ─┘
+```
+
+Categories:
+
+```text
+category         predicates expanded                                    how variants chosen
+──────────────   ──────────────────────────────────────────────────    ──────────────────────
+coding           pLoF, missense, disruptive_missense, pLoF_missense,   consequence + CADD + REVEL
+                 synonymous, ptv, ptv_ds
+noncoding        upstream, downstream, UTR, promoter_CAGE, promoter_   region_type + regulatory
+                 DHS, enhancer_CAGE, enhancer_DHS, ncRNA                flags
+sliding-window   fixed-width chunks (default 2 kb, step 2 kb)          positional
+scang            variable-width chunks, L ∈ [lmin, lmax] variants      positional (data-adaptive)
+custom           user BED (not yet wired)                              user-supplied
+```
+
+### Speed
+
+`variants.parquet` is columnar, so a predicate filter is a column scan
+over `consequence` / `cadd_phred` / regulatory flags. `membership.parquet`
+is pre-sorted by `(gene, variant_vcf)` so "all variants in gene G" is a
+range scan.
+
+## Output Shape
+
+One row per gene, one parquet per mask.
+
+```text
+INPUT                TRANSFORMATION              OUTPUT ROW (per gene)
+──────────────────   ─────────────────────       ────────────────────────────────
+U (m,)           ─┐                               ensembl_id, gene_symbol, chr,
+K (m, m)          ├─ test battery ─────────────► start, end, n_variants, cMAC
+w (11, m)        ─┘  + Cauchy combine            6 base tests       (f64, nullable)
+                                                 66 weighted tests  (test × channel)
+                                                 6 per-test omnibus (STAAR-B/S/A)
+                                                 ACAT-O, STAAR-O
+```
+
+A gene row comes out null on a mask if `< 2` variants qualify or the
+kernel degenerates.
+
+## EmitSumstats and MetaSTAAR
+
+`EmitSumstats` stops after the null fit and writes per-variant stats in a
+form another study can pool later. Shape of what gets written per segment
+(~500 kb genomic slice):
+
+```text
+INPUT                           TRANSFORMATION              OUTPUT (segment row)
+────────────────────────        ─────────────────────       ──────────────────────────
+r (n,)  from null          ─┐                               segment_id   u32
+genotype slice (n, m)       ├─ U = G'r                      positions    [i32; m]
+  (m variants in segment)   │  K = G' P̂ G  (lower tri)      refs         [utf8; m]
+per-variant MAC, n_obs      ─┘                              alts         [utf8; m]
+                                                            u_stat       [f64; m]
+                                                            cov_lower    [f64; m(m+1)/2]
+                                                            mac          [u32; m]
+                                                            n_obs        [i32; m]
+```
+
+Lower triangle only — `K` is symmetric, so storing `m(m+1)/2` halves the
+disk. Alleles are stored in canonical (lex-min) orientation so later
+UNION-ALL across studies works without per-row flip logic at query time.
+
+`favor meta-staar` pools these across studies:
+
+```text
+INPUT                              TRANSFORMATION                  OUTPUT
+────────────────────────────       ─────────────────────────       ───────────────
+study 1: (U₁, K₁) per segment  ─┐                                   U_meta  (M,)
+study 2: (U₂, K₂) per segment  ─┼─ per canonical variant v:          K_meta  (M, M)
+...                             │    U_meta[v] = Σ sign_s · U_s[v]    → same test
+                                └─   K_meta[v,w] = Σ s_v·s_w · K_s    battery as
+                                                                      single-study
+                                                                      per-mask parquet
+```
+
+`sign_s ∈ {+1, −1}` flips when a study encoded the variant with the minor
+allele on the other side. `M` is the union size over studies. The
+canonical orientation in sumstats pushes all flip bookkeeping to one
+lookup at merge time.
+
+## MultiTrait
+
+Joint null for `k` continuous traits sharing one covariate set.
+
+```text
+INPUT                       TRANSFORMATION              OUTPUT
+──────────────────────      ─────────────────────       ──────────────────────
+Y     (n, k)   traits    ─┐                              R       (n, k)    residuals
+X     (n, p+1) covars    ─┼─ joint OLS / REML ─────►     Σ_res   (k, k)    residual cov
+                                                         Σ_res⁻¹           (cached for SKAT)
+```
+
+`Σ_res` replaces `σ²` in the score-test kernel. Each gene × mask still
+yields one joint p-value. v0.2: continuous traits only, no kinship.
+
+## Caching
+
+Three layers (see [storage](storage.md) for details):
+
+```text
+layer   artifact                         invalidated by
+─────   ──────────────────────────────   ──────────────────────────────────
+  1     sparse genotype store            VCF or annotation fingerprint change
+  2     null model (Glm / Logistic)      phenotype or covariate change
+  3     score cache (U, K blocks)        store rebuild, mask / MAF change
+```
+
+Swap the mask → layer 3 only. Swap the phenotype → 2 and 3. Rebuild store
+→ all three.
+
+## See Also
+
+- [Genotype store](storage.md) — sparse G, variant index, score cache
+- [Validation](validation.md) — R STAAR reference and tolerances
+- [Statistical divergences](statistical-divergences.md) — known differences from R STAAR / SKAT
+- [Performance](performance.md) — hot paths and memory picture

--- a/docs/statistical-divergences.md
+++ b/docs/statistical-divergences.md
@@ -1,5 +1,7 @@
 # Statistical Divergences from R
 
+> [Back to README](../README.md) · [STAAR](staar.md) · [Validation](validation.md)
+
 Where favor-cli differs from the R reference packages and why.
 
 ## SKAT p-value: moment-matching vs eigenvalue saddlepoint

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -15,7 +15,7 @@ to a single variant index so STAAR/burden/SKAT runs are fast.
 
 If the input VCF changes, the store is rebuilt.
 
-> [Back to README](../README.md) · [Performance](performance.md)
+> [Back to README](../README.md) · [STAAR](staar.md) · [Performance](performance.md)
 
 ## Why Sparse?
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1,6 +1,6 @@
 # STAAR Statistical Validation
 
-> [Back to README](../README.md)
+> [Back to README](../README.md) · [STAAR](staar.md)
 
 FAVOR CLI's STAAR implementation is validated against the official R packages from the [Lin Lab](https://content.sph.harvard.edu/xlin/) (Harvard T.H. Chan School of Public Health).
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,6 +32,21 @@ impl CohortError {
             Self::Cancelled => "cancelled",
         }
     }
+
+    /// Prepend a context label to the error message while preserving the
+    /// variant (and therefore the exit code). Used at parallel-worker
+    /// boundaries where we want to attach `(worker_id, file path)` to an
+    /// otherwise opaque error without losing its classification.
+    pub fn with_context(self, ctx: impl std::fmt::Display) -> Self {
+        match self {
+            Self::Input(m) => Self::Input(format!("{ctx}: {m}")),
+            Self::DataMissing(m) => Self::DataMissing(format!("{ctx}: {m}")),
+            Self::Resource(m) => Self::Resource(format!("{ctx}: {m}")),
+            Self::Analysis(m) => Self::Analysis(format!("{ctx}: {m}")),
+            Self::Internal(e) => Self::Internal(e.context(ctx.to_string())),
+            Self::Cancelled => Self::Cancelled,
+        }
+    }
 }
 
 impl fmt::Display for CohortError {

--- a/src/ingest/vcf.rs
+++ b/src/ingest/vcf.rs
@@ -640,6 +640,11 @@ pub fn ingest_vcfs_parallel(
 ) -> Result<VcfIngestResult, CohortError> {
     use rayon::prelude::*;
 
+    let threads = preflight(
+        input_paths, output_dir, geno_dir, n_samples,
+        memory_budget, threads, output,
+    )?;
+
     if n_samples > 0 {
         output.status("  Validating sample consistency across files...");
         validate_headers_parallel(input_paths, n_samples)?;
@@ -670,23 +675,18 @@ pub fn ingest_vcfs_parallel(
     let results: Vec<VcfIngestResult> = chunks
         .into_par_iter()
         .enumerate()
-        .map(|(worker_id, file_chunk)| -> Result<VcfIngestResult, CohortError> {
-            let mut gw = match geno_dir {
-                Some(gd) => Some(GenotypeWriter::with_part_id(
-                    n_samples, gd, memory_per_worker, Some(worker_id),
-                )?),
-                None => None,
-            };
-            let mut ctx = RecordContext::new(
-                gw.as_mut(), memory_per_worker,
-                output_dir.to_path_buf(), Some(worker_id),
-            );
-            ctx.ingest_files(&file_chunk, 1, output)?;
-            let result = ctx.flush()?;
-            if let Some(mut g) = gw {
-                g.flush_all()?;
-            }
-            Ok(result)
+        .map(|(worker_id, file_chunk)| {
+            run_worker(
+                worker_id, &file_chunk, output_dir, geno_dir,
+                n_samples, memory_per_worker, output,
+            )
+            .map_err(|e| e.with_context(format!(
+                "worker {worker_id} ({})",
+                file_chunk.iter()
+                    .map(|p| p.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            )))
         })
         .collect::<Result<Vec<_>, _>>()?;
 
@@ -703,9 +703,171 @@ pub fn ingest_vcfs_parallel(
     Ok(total)
 }
 
+/// One rayon worker: own a `GenotypeWriter` and a `RecordContext`, ingest the
+/// file chunk sequentially, close both cleanly. Extracted so the caller can
+/// attach `(worker_id, file paths)` to any error via `with_context`.
+fn run_worker(
+    worker_id: usize,
+    file_chunk: &[&PathBuf],
+    output_dir: &Path,
+    geno_dir: Option<&Path>,
+    n_samples: usize,
+    memory_per_worker: u64,
+    output: &dyn Output,
+) -> Result<VcfIngestResult, CohortError> {
+    let mut gw = match geno_dir {
+        Some(gd) => Some(GenotypeWriter::with_part_id(
+            n_samples, gd, memory_per_worker, Some(worker_id),
+        )?),
+        None => None,
+    };
+    let mut ctx = RecordContext::new(
+        gw.as_mut(), memory_per_worker,
+        output_dir.to_path_buf(), Some(worker_id),
+    );
+    ctx.ingest_files(file_chunk, 1, output)?;
+    let result = ctx.flush()?;
+    if let Some(mut g) = gw {
+        g.flush_all()?;
+    }
+    Ok(result)
+}
+
+/// Pre-flight checks for parallel VCF ingest. Catches duplicate input paths,
+/// stale part files from a prior failed run, insufficient fd headroom, and
+/// memory budgets that would starve the genotype writer. Returns the
+/// (possibly reduced) worker count that is safe to spawn.
+fn preflight(
+    input_paths: &[PathBuf],
+    output_dir: &Path,
+    geno_dir: Option<&Path>,
+    n_samples: usize,
+    memory_budget: u64,
+    requested_threads: usize,
+    output: &dyn Output,
+) -> Result<usize, CohortError> {
+    dedup_canonical(input_paths)?;
+    let mut roots: Vec<&Path> = vec![output_dir];
+    if let Some(gd) = geno_dir { roots.push(gd); }
+    clean_stale_parts(&roots, output)?;
+    let threads = cap_threads_for_fds(requested_threads, output)?;
+    let threads = cap_threads_for_batch_size(
+        n_samples, memory_budget, threads, geno_dir.is_some(),
+    )?;
+    Ok(threads)
+}
+
+fn dedup_canonical(paths: &[PathBuf]) -> Result<(), CohortError> {
+    use std::collections::HashSet;
+    let mut seen = HashSet::with_capacity(paths.len());
+    for p in paths {
+        let canon = std::fs::canonicalize(p).map_err(|e| {
+            CohortError::Input(format!("cannot open '{}': {e}", p.display()))
+        })?;
+        if !seen.insert(canon) {
+            return Err(CohortError::Input(format!(
+                "duplicate VCF input: '{}' (each file must appear at most once)",
+                p.display(),
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn clean_stale_parts(roots: &[&Path], output: &dyn Output) -> Result<(), CohortError> {
+    let mut removed = 0usize;
+    for root in roots {
+        if !root.exists() { continue; }
+        // Parts live at root/chromosome=<chr>/part_<id>.parquet (depth 2).
+        for entry in walkdir::WalkDir::new(root).min_depth(2).max_depth(2) {
+            let entry = entry.map_err(|e| CohortError::Resource(format!(
+                "cannot scan '{}': {e}", root.display(),
+            )))?;
+            let name = entry.file_name().to_string_lossy();
+            if name.starts_with("part_") && name.ends_with(".parquet") {
+                std::fs::remove_file(entry.path()).map_err(|e| CohortError::Resource(format!(
+                    "cannot remove stale part '{}': {e}", entry.path().display(),
+                )))?;
+                removed += 1;
+            }
+        }
+    }
+    if removed > 0 {
+        output.status(&format!("  Preflight: cleaned {removed} stale part file(s)"));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn fd_soft_limit() -> Option<u64> {
+    let mut rlim = libc::rlimit { rlim_cur: 0, rlim_max: 0 };
+    // SAFETY: `rlim` is a valid local; RLIMIT_NOFILE is the standard descriptor resource.
+    let rc = unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut rlim) };
+    if rc == 0 { Some(rlim.rlim_cur) } else { None }
+}
+#[cfg(not(unix))]
+fn fd_soft_limit() -> Option<u64> { None }
+
+// Per-worker fd cost: ~24 chromosome parquet writers + bgzf reader +
+// genotype writer + slack. Baseline covers stdio, mmap handles, etc.
+// Usable fraction is 80% of the soft limit — leaves headroom for lib internals.
+fn fd_safe_workers(limit: u64) -> usize {
+    const FDS_PER_WORKER: u64 = 30;
+    const BASELINE_FDS: u64 = 64;
+    // `limit / 10 * 8` avoids overflow at the u64::MAX edge cases exercised by tests.
+    let budget = (limit / 10 * 8).saturating_sub(BASELINE_FDS);
+    (budget / FDS_PER_WORKER) as usize
+}
+
+fn cap_threads_for_fds(threads: usize, output: &dyn Output) -> Result<usize, CohortError> {
+    let Some(limit) = fd_soft_limit() else { return Ok(threads); };
+    let safe = fd_safe_workers(limit);
+    if safe == 0 {
+        return Err(CohortError::Resource(format!(
+            "fd soft limit {limit} too low for parallel ingest; \
+             raise with `ulimit -n 4096` and retry",
+        )));
+    }
+    if threads <= safe { return Ok(threads); }
+    output.status(&format!(
+        "  Preflight: capping workers {threads} -> {safe} (fd soft limit {limit})",
+    ));
+    Ok(safe)
+}
+
+fn cap_threads_for_batch_size(
+    n_samples: usize,
+    memory_budget: u64,
+    threads: usize,
+    writes_genotypes: bool,
+) -> Result<usize, CohortError> {
+    // Viability floor for the GenotypeWriter row-group. Below this the writer
+    // flushes per variant, killing throughput.
+    const MIN_VIABLE_BATCH: u64 = 500;
+    if !writes_genotypes || n_samples == 0 { return Ok(threads); }
+    // Find the largest worker count where per-worker raw capacity still clears MIN.
+    let mut t = threads.max(1);
+    while t > 1 && crate::staar::genotype::raw_batch_size(n_samples, memory_budget / t as u64)
+        < MIN_VIABLE_BATCH
+    {
+        t -= 1;
+    }
+    if crate::staar::genotype::raw_batch_size(n_samples, memory_budget / t as u64)
+        < MIN_VIABLE_BATCH
+    {
+        return Err(CohortError::Resource(format!(
+            "memory budget {:.1}G too small for {n_samples} samples \
+             (even 1 worker can't batch {MIN_VIABLE_BATCH} variants); \
+             raise --memory or reduce sample count",
+            memory_budget as f64 / (1u64 << 30) as f64,
+        )));
+    }
+    Ok(t)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::parsimony_normalize;
+    use super::*;
 
     #[test]
     fn snv() { assert_eq!(parsimony_normalize("G", "A", 100), ("G", "A", 100)); }
@@ -731,5 +893,126 @@ mod tests {
         let (nr, na, _) = parsimony_normalize(r, a, 100);
         assert!(std::ptr::eq(nr.as_ptr(), r[2..3].as_ptr()));
         assert!(std::ptr::eq(na.as_ptr(), a[2..3].as_ptr()));
+    }
+
+    struct SilentOutput;
+    impl crate::output::Output for SilentOutput {
+        fn status(&self, _msg: &str) {}
+        fn success(&self, _msg: &str) {}
+        fn warn(&self, _msg: &str) {}
+        fn error(&self, _err: &CohortError) {}
+        fn result_json(&self, _data: &serde_json::Value) {}
+        fn table(&self, _headers: &[&str], _rows: &[Vec<String>]) {}
+        fn progress(&self, _total: u64, _label: &str) -> crate::output::Progress {
+            crate::output::Progress::noop()
+        }
+    }
+
+    fn touch(path: &Path) {
+        std::fs::write(path, b"").unwrap();
+    }
+
+    #[test]
+    fn dedup_canonical_rejects_same_file_twice() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("a.vcf.gz");
+        touch(&p);
+        let err = dedup_canonical(&[p.clone(), p.clone()]).unwrap_err();
+        assert!(matches!(err, CohortError::Input(ref m) if m.contains("duplicate")), "got {err:?}");
+    }
+
+    #[test]
+    fn dedup_canonical_accepts_distinct_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let a = tmp.path().join("a.vcf.gz");
+        let b = tmp.path().join("b.vcf.gz");
+        touch(&a);
+        touch(&b);
+        assert!(dedup_canonical(&[a, b]).is_ok());
+    }
+
+    #[test]
+    fn dedup_canonical_resolves_symlinks_to_same_target() {
+        // Two distinct paths both pointing at the same file should be flagged.
+        let tmp = tempfile::tempdir().unwrap();
+        let real = tmp.path().join("real.vcf.gz");
+        let link = tmp.path().join("link.vcf.gz");
+        touch(&real);
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+        #[cfg(not(unix))]
+        touch(&link); // can't symlink without privileges; plain touch still makes two distinct paths
+        let err = dedup_canonical(&[real, link]);
+        #[cfg(unix)]
+        assert!(matches!(err, Err(CohortError::Input(_))));
+        #[cfg(not(unix))]
+        assert!(err.is_ok()); // distinct files, not actually the same
+    }
+
+    #[test]
+    fn clean_stale_parts_removes_parts_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let chr_dir = tmp.path().join("chromosome=22");
+        std::fs::create_dir_all(&chr_dir).unwrap();
+        touch(&chr_dir.join("part_0.parquet"));
+        touch(&chr_dir.join("part_1.parquet"));
+        touch(&chr_dir.join("data.parquet"));       // not a part file
+        touch(&chr_dir.join("other.txt"));          // unrelated
+        clean_stale_parts(&[tmp.path()], &SilentOutput).unwrap();
+        assert!(!chr_dir.join("part_0.parquet").exists());
+        assert!(!chr_dir.join("part_1.parquet").exists());
+        assert!(chr_dir.join("data.parquet").exists());
+        assert!(chr_dir.join("other.txt").exists());
+    }
+
+    #[test]
+    fn clean_stale_parts_missing_root_is_ok() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("does-not-exist");
+        assert!(clean_stale_parts(&[&missing], &SilentOutput).is_ok());
+    }
+
+    #[test]
+    fn fd_safe_workers_scales_with_limit() {
+        assert_eq!(fd_safe_workers(64), 0);         // below baseline
+        assert!(fd_safe_workers(1024) >= 20);       // default ulimit gives many workers
+        assert!(fd_safe_workers(4096) > fd_safe_workers(1024));
+        assert!(fd_safe_workers(u64::MAX) > 0);     // no overflow
+    }
+
+    #[test]
+    fn cap_threads_for_batch_size_no_genotypes_passthrough() {
+        // No genotype writer => no viability check, threads unchanged.
+        let got = cap_threads_for_batch_size(0, 1 << 20, 16, false).unwrap();
+        assert_eq!(got, 16);
+    }
+
+    #[test]
+    fn cap_threads_for_batch_size_reduces_when_memory_low() {
+        // 200k samples, 16 GiB budget — enough for a handful of workers, not 64.
+        let capped = cap_threads_for_batch_size(200_000, 16u64 << 30, 64, true).unwrap();
+        assert!((1..64).contains(&capped), "expected cap, got {capped}");
+    }
+
+    #[test]
+    fn cap_threads_for_batch_size_errors_on_starved_single_worker() {
+        // 1 MiB for 200k samples — even 1 worker can't batch 500 variants.
+        let err = cap_threads_for_batch_size(200_000, 1 << 20, 1, true).unwrap_err();
+        assert!(matches!(err, CohortError::Resource(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn cap_threads_for_batch_size_passes_when_memory_ample() {
+        // 64 GiB, 10k samples, 8 workers — all fit comfortably.
+        let got = cap_threads_for_batch_size(10_000, 64u64 << 30, 8, true).unwrap();
+        assert_eq!(got, 8);
+    }
+
+    #[test]
+    fn error_with_context_preserves_variant() {
+        let e = CohortError::Input("bad".into()).with_context("worker 3");
+        assert!(matches!(e, CohortError::Input(ref m) if m == "worker 3: bad"));
+        let e = CohortError::Resource("hm".into()).with_context("worker 3");
+        assert!(matches!(e, CohortError::Resource(ref m) if m == "worker 3: hm"));
     }
 }

--- a/src/staar/genotype.rs
+++ b/src/staar/genotype.rs
@@ -185,12 +185,8 @@ impl GenotypeWriter {
         available_memory: u64,
         part_id: Option<usize>,
     ) -> Result<Self, CohortError> {
-        // FixedSizeListBuilder holds batch_size * n_samples * 4 bytes.
-        // Arrow's finish() temporarily doubles this creating new arrays.
-        // Use 1/4 of budget for the batch to leave room for the copy + overhead.
-        let bytes_per_variant = (n_samples as u64) * 4 + 200;
         let batch_size =
-            ((available_memory / 4) / bytes_per_variant).clamp(1000, 100_000) as usize;
+            raw_batch_size(n_samples, available_memory).clamp(1000, 100_000) as usize;
 
         let geno_dir = output_dir.to_path_buf();
         std::fs::create_dir_all(&geno_dir).map_err(|e| {
@@ -321,9 +317,11 @@ impl GenotypeWriter {
             CohortError::Resource(format!("Cannot write '{}': {e}", meta_path.display()))
         })?;
 
+        // `Drop` is implemented on `Self`, so fields can't be partial-moved;
+        // swap `geno_dir` out with a default instead.
         Ok(GenotypeResult {
             sample_names: sample_names.to_vec(),
-            output_dir: self.geno_dir,
+            output_dir: std::mem::take(&mut self.geno_dir),
         })
     }
 
@@ -378,6 +376,17 @@ impl GenotypeWriter {
     }
 }
 
+// Close parquet footer on unwind so a panicking rayon worker can't leave a
+// truncated, unreadable parquet behind. Normal paths (`flush_all`, `finish`,
+// `switch_chrom`) already `take` the writer, so this only fires during panic.
+impl Drop for GenotypeWriter {
+    fn drop(&mut self) {
+        if let Some(w) = self.writer.take() {
+            let _ = w.close();
+        }
+    }
+}
+
 fn process_record_geno(
     record: &noodles_vcf::Record,
     gw: &mut GenotypeWriter,
@@ -410,6 +419,18 @@ fn process_record_geno(
         gw.push(chrom, np, nr, na, samples_str, (alt_idx + 1) as u8, output)?;
     }
     Ok(())
+}
+
+/// Row-group capacity the GenotypeWriter would allocate under `available_memory`,
+/// before the 1k..100k clamp. Shared with the ingest preflight so it can reject
+/// configurations whose raw capacity would force flush-per-variant throughput.
+///
+/// The `/ 4` factor matches the writer's internal reservation: the
+/// FixedSizeListBuilder holds `batch_size * n_samples * 4` bytes, Arrow's
+/// `finish()` briefly doubles that during copy-out.
+pub fn raw_batch_size(n_samples: usize, available_memory: u64) -> u64 {
+    let bytes_per_variant = (n_samples as u64) * 4 + 200;
+    (available_memory / 4) / bytes_per_variant
 }
 
 fn packed_schema(n_samples: usize) -> Schema {
@@ -622,4 +643,53 @@ pub fn load(
     }
     let _ = engine.execute("DROP TABLE IF EXISTS _geno_load");
     Ok(flat)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::panic::{self, AssertUnwindSafe};
+
+    struct SilentOutput;
+    impl crate::output::Output for SilentOutput {
+        fn status(&self, _msg: &str) {}
+        fn success(&self, _msg: &str) {}
+        fn warn(&self, _msg: &str) {}
+        fn error(&self, _err: &CohortError) {}
+        fn result_json(&self, _data: &serde_json::Value) {}
+        fn table(&self, _headers: &[&str], _rows: &[Vec<String>]) {}
+        fn progress(&self, _total: u64, _label: &str) -> crate::output::Progress {
+            crate::output::Progress::noop()
+        }
+    }
+
+    #[test]
+    fn raw_batch_size_matches_expected_formula() {
+        // 1 MiB budget, 256 samples -> (1 MiB / 4) / (256*4+200) = ~217
+        let got = raw_batch_size(256, 1 << 20);
+        assert!(got > 200 && got < 230, "got {got}");
+        // Zero samples => overhead-only denominator (200 bytes).
+        assert_eq!(raw_batch_size(0, 800), 1);
+    }
+
+    #[test]
+    fn drop_closes_parquet_footer_on_panic() {
+        // Panicking inside a rayon worker must not leave a truncated, unreadable
+        // parquet: the Drop impl writes the footer during unwind.
+        let tmp = tempfile::tempdir().unwrap();
+        let out = SilentOutput;
+        let caught = panic::catch_unwind(AssertUnwindSafe(|| {
+            let mut gw = GenotypeWriter::new(2, tmp.path(), 64 << 20).unwrap();
+            // One biallelic SNV, two samples. GT field = "0/0\t0/1".
+            gw.push("22", 15_000_000, "A", "G", "0/0\t0/1", 1, &out).unwrap();
+            panic!("simulated worker panic before flush_all");
+        }));
+        assert!(caught.is_err(), "expected panic to propagate");
+
+        let parquet_path = tmp.path().join("chromosome=22").join("data.parquet");
+        assert!(parquet_path.exists(), "parquet missing at {}", parquet_path.display());
+        let f = std::fs::File::open(&parquet_path).unwrap();
+        let reader = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(f);
+        assert!(reader.is_ok(), "parquet footer missing: {:?}", reader.err());
+    }
 }


### PR DESCRIPTION
Two new pages. docs/staar.md walks the STAAR pipeline with input → transformation → output figures (null fit, score test, masks, output, sumstats + meta, multi-trait, caching). docs/ingest.md documents the two recommended patterns (per-chromosome SLURM vs single-node parallel), what preflight checks, the throughput table, and machine mode.

Linked from README. Back-links added from storage, performance, validation, statistical-divergences.


Closes #85.