### PR TITLE
ingest: --chromosome filter

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -137,6 +137,12 @@ pub enum Command {
         /// Force rebuild of the cohort store even if a valid one exists
         #[arg(long)]
         rebuild: bool,
+
+        /// Restrict ingest to these chromosomes. Accepts `22`, `1,2,3`,
+        /// `1-22`, or combinations like `1-22,X,Y,MT`. Default: all standard
+        /// chromosomes.
+        #[arg(long, value_name = "SPEC")]
+        chromosome: Option<crate::types::ChromosomeSet>,
     },
 
     /// Annotate variants against FAVOR base or full tier

--- a/src/commands/ingest.rs
+++ b/src/commands/ingest.rs
@@ -62,6 +62,7 @@ pub(crate) fn resolve_inputs(raw: Vec<PathBuf>) -> Result<Vec<PathBuf>, CohortEr
     Ok(resolved)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn build_config(
     raw_inputs: Vec<PathBuf>,
     output: Option<PathBuf>,
@@ -70,6 +71,7 @@ pub fn build_config(
     annotations: Option<PathBuf>,
     cohort_id: Option<String>,
     rebuild: bool,
+    chromosome_filter: Option<crate::types::ChromosomeSet>,
 ) -> Result<IngestConfig, CohortError> {
     let inputs = resolve_inputs(raw_inputs)?;
 
@@ -100,6 +102,7 @@ pub fn build_config(
         annotations,
         cohort_id,
         rebuild,
+        chromosome_filter,
     })
 }
 
@@ -344,6 +347,7 @@ fn ingest_vcf(
             n_samples,
             resources.memory_bytes,
             resources.threads,
+            config.chromosome_filter.as_ref(),
             out,
         )?;
 
@@ -398,6 +402,7 @@ fn ingest_vcf(
             geno_writer.as_mut(),
             resources.memory_bytes,
             resources.threads,
+            config.chromosome_filter.as_ref(),
             out,
         )?;
         let vs = vs_writer.finish()?;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -38,6 +38,7 @@ pub struct IngestConfig {
     pub annotations: Option<PathBuf>,
     pub cohort_id: Option<String>,
     pub rebuild: bool,
+    pub chromosome_filter: Option<crate::types::ChromosomeSet>,
 }
 
 pub fn derive_cohort_id(genotypes: &Path) -> String {

--- a/src/ingest/vcf.rs
+++ b/src/ingest/vcf.rs
@@ -286,6 +286,7 @@ struct RecordContext<'a> {
     batch_size: usize,
     output_dir: PathBuf,
     part_id: Option<usize>,
+    chromosome_filter: Option<crate::types::ChromosomeSet>,
     variant_count: u64,
     filtered_contigs: u64,
     multiallelic_split: u64,
@@ -297,6 +298,7 @@ impl<'a> RecordContext<'a> {
         memory_budget: u64,
         output_dir: PathBuf,
         part_id: Option<usize>,
+        chromosome_filter: Option<crate::types::ChromosomeSet>,
     ) -> Self {
         let batch_size = derive_batch_size(memory_budget);
         let schema = Arc::new(vcf_schema());
@@ -315,6 +317,7 @@ impl<'a> RecordContext<'a> {
             batch_size,
             output_dir,
             part_id,
+            chromosome_filter,
             variant_count: 0,
             filtered_contigs: 0,
             multiallelic_split: 0,
@@ -341,6 +344,12 @@ impl<'a> RecordContext<'a> {
             Some(c) => c,
             None => { self.filtered_contigs += 1; return Ok(()); }
         };
+        if let Some(filt) = &self.chromosome_filter {
+            if !filt.contains_canonical(chrom) {
+                self.filtered_contigs += 1;
+                return Ok(());
+            }
+        }
         let pos = match record.variant_start() {
             Some(Ok(p)) => p.get() as i32,
             _ => return Ok(()),
@@ -571,17 +580,20 @@ impl<'a> RecordContext<'a> {
 }
 
 /// Stream one or more VCF files to per-chromosome parquet files (sequential).
+#[allow(clippy::too_many_arguments)]
 pub fn ingest_vcfs(
     input_paths: &[PathBuf],
     vs_writer: &mut VariantSetWriter,
     geno_writer: Option<&mut GenotypeWriter>,
     memory_budget: u64,
     threads: usize,
+    chromosome_filter: Option<&crate::types::ChromosomeSet>,
     output: &dyn Output,
 ) -> Result<VcfIngestResult, CohortError> {
     let mut ctx = RecordContext::new(
         geno_writer, memory_budget,
         vs_writer.root().to_path_buf(), None,
+        chromosome_filter.cloned(),
     );
     output.status(&format!(
         "  Batch size: {} variants/chrom ({:.1}G memory)",
@@ -629,6 +641,7 @@ fn validate_headers_parallel(
 /// Parallel multi-file VCF ingest. Files are chunked across N workers,
 /// each worker processes its chunk sequentially with a single RecordContext.
 /// N is bounded by thread count. Validates headers before spawning.
+#[allow(clippy::too_many_arguments)]
 pub fn ingest_vcfs_parallel(
     input_paths: &[PathBuf],
     output_dir: &Path,
@@ -636,6 +649,7 @@ pub fn ingest_vcfs_parallel(
     n_samples: usize,
     memory_budget: u64,
     threads: usize,
+    chromosome_filter: Option<&crate::types::ChromosomeSet>,
     output: &dyn Output,
 ) -> Result<VcfIngestResult, CohortError> {
     use rayon::prelude::*;
@@ -678,7 +692,9 @@ pub fn ingest_vcfs_parallel(
         .map(|(worker_id, file_chunk)| {
             run_worker(
                 worker_id, &file_chunk, output_dir, geno_dir,
-                n_samples, memory_per_worker, output,
+                n_samples, memory_per_worker,
+                chromosome_filter.cloned(),
+                output,
             )
             .map_err(|e| e.with_context(format!(
                 "worker {worker_id} ({})",
@@ -706,6 +722,7 @@ pub fn ingest_vcfs_parallel(
 /// One rayon worker: own a `GenotypeWriter` and a `RecordContext`, ingest the
 /// file chunk sequentially, close both cleanly. Extracted so the caller can
 /// attach `(worker_id, file paths)` to any error via `with_context`.
+#[allow(clippy::too_many_arguments)]
 fn run_worker(
     worker_id: usize,
     file_chunk: &[&PathBuf],
@@ -713,6 +730,7 @@ fn run_worker(
     geno_dir: Option<&Path>,
     n_samples: usize,
     memory_per_worker: u64,
+    chromosome_filter: Option<crate::types::ChromosomeSet>,
     output: &dyn Output,
 ) -> Result<VcfIngestResult, CohortError> {
     let mut gw = match geno_dir {
@@ -724,6 +742,7 @@ fn run_worker(
     let mut ctx = RecordContext::new(
         gw.as_mut(), memory_per_worker,
         output_dir.to_path_buf(), Some(worker_id),
+        chromosome_filter,
     );
     ctx.ingest_files(file_chunk, 1, output)?;
     let result = ctx.flush()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,7 @@ fn run(
             annotations,
             cohort_id,
             rebuild,
+            chromosome,
         } => {
             let engine = runtime::Engine::open_unconfigured(store_path)?;
             let config = commands::ingest::build_config(
@@ -102,6 +103,7 @@ fn run(
                 annotations,
                 cohort_id,
                 rebuild,
+                chromosome,
             )?;
             commands::ingest::run_ingest(&engine, &config, out, dry_run)
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -94,6 +94,80 @@ impl<'de> Deserialize<'de> for Chromosome {
     }
 }
 
+/// Filterable subset of the 25 canonical chromosomes (1-22, X, Y, MT).
+/// Parsed from CLI specs like `"22"`, `"1,2,3"`, `"1-22"`, `"1-22,X,Y,MT"`.
+/// Named chromosomes (X, Y, MT) may only appear as single tokens, never in
+/// a range — `"X-Y"` is an error.
+#[derive(Default, Clone, Debug, PartialEq, Eq)]
+pub struct ChromosomeSet {
+    bits: [bool; 25],
+}
+
+impl ChromosomeSet {
+    fn index(c: Chromosome) -> usize {
+        match c {
+            Chromosome::Autosome(n) => (n - 1) as usize,
+            Chromosome::X => 22,
+            Chromosome::Y => 23,
+            Chromosome::MT => 24,
+        }
+    }
+
+    pub fn insert(&mut self, c: Chromosome) {
+        self.bits[Self::index(c)] = true;
+    }
+
+    /// Fast membership check against the canonical strings that
+    /// `ingest::vcf::normalize_chrom` emits (`"1"`..`"22"`, `"X"`, `"Y"`, `"MT"`).
+    pub fn contains_canonical(&self, s: &str) -> bool {
+        match s {
+            "X" => self.bits[22],
+            "Y" => self.bits[23],
+            "MT" => self.bits[24],
+            _ => s.parse::<u8>().ok()
+                .filter(|n| (1..=22).contains(n))
+                .map(|n| self.bits[(n - 1) as usize])
+                .unwrap_or(false),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        !self.bits.iter().any(|b| *b)
+    }
+}
+
+impl FromStr for ChromosomeSet {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut set = ChromosomeSet::default();
+        for token in s.split(',').map(str::trim).filter(|t| !t.is_empty()) {
+            if let Some((a, b)) = token.split_once('-') {
+                let start: u8 = a.trim().parse()
+                    .map_err(|_| format!("range must use autosomes 1-22: '{token}'"))?;
+                let end: u8 = b.trim().parse()
+                    .map_err(|_| format!("range must use autosomes 1-22: '{token}'"))?;
+                if !(1..=22).contains(&start) || !(1..=22).contains(&end) {
+                    return Err(format!("range {token} outside autosomes 1-22"));
+                }
+                if start > end {
+                    return Err(format!("reversed range: '{token}'"));
+                }
+                for n in start..=end {
+                    set.insert(Chromosome::Autosome(n));
+                }
+            } else {
+                let c: Chromosome = token.parse()?;
+                set.insert(c);
+            }
+        }
+        if set.is_empty() {
+            return Err("no chromosomes specified".into());
+        }
+        Ok(set)
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct AnnotationWeights(pub [f64; 11]);
 
@@ -502,6 +576,84 @@ mod tests {
         assert_eq!(json, "\"chr7\"");
         let back: Chromosome = serde_json::from_str(&json).unwrap();
         assert_eq!(back, c);
+    }
+
+    #[test]
+    fn chromset_single_token() {
+        let s: ChromosomeSet = "22".parse().unwrap();
+        assert!(s.contains_canonical("22"));
+        assert!(!s.contains_canonical("21"));
+        assert!(!s.contains_canonical("X"));
+    }
+
+    #[test]
+    fn chromset_comma_list() {
+        let s: ChromosomeSet = "1,3,X,MT".parse().unwrap();
+        for c in ["1", "3", "X", "MT"] {
+            assert!(s.contains_canonical(c), "missing {c}");
+        }
+        assert!(!s.contains_canonical("2"));
+        assert!(!s.contains_canonical("Y"));
+    }
+
+    #[test]
+    fn chromset_range_expands() {
+        let s: ChromosomeSet = "1-5".parse().unwrap();
+        for n in 1..=5u8 {
+            assert!(s.contains_canonical(&n.to_string()), "missing {n}");
+        }
+        assert!(!s.contains_canonical("6"));
+    }
+
+    #[test]
+    fn chromset_mixed() {
+        let s: ChromosomeSet = "1-3,22,X,Y".parse().unwrap();
+        for c in ["1", "2", "3", "22", "X", "Y"] {
+            assert!(s.contains_canonical(c), "missing {c}");
+        }
+        assert!(!s.contains_canonical("4"));
+        assert!(!s.contains_canonical("MT"));
+    }
+
+    #[test]
+    fn chromset_contains_canonical() {
+        let s: ChromosomeSet = "1-22,X,Y,MT".parse().unwrap();
+        // Every canonical string normalize_chrom emits should hit.
+        for n in 1..=22u8 {
+            assert!(s.contains_canonical(&n.to_string()), "missing {n}");
+        }
+        for c in ["X", "Y", "MT"] {
+            assert!(s.contains_canonical(c), "missing {c}");
+        }
+        // Uncanonical inputs don't match.
+        assert!(!s.contains_canonical("chr1"));
+        assert!(!s.contains_canonical("banana"));
+        assert!(!s.contains_canonical("23"));
+    }
+
+    #[test]
+    fn chromset_empty_spec_is_error() {
+        assert!("".parse::<ChromosomeSet>().is_err());
+        assert!(",".parse::<ChromosomeSet>().is_err());
+    }
+
+    #[test]
+    fn chromset_reversed_range_is_error() {
+        let e = "10-5".parse::<ChromosomeSet>().unwrap_err();
+        assert!(e.contains("reversed"), "got: {e}");
+    }
+
+    #[test]
+    fn chromset_named_in_range_is_error() {
+        assert!("X-Y".parse::<ChromosomeSet>().is_err());
+        assert!("1-X".parse::<ChromosomeSet>().is_err());
+    }
+
+    #[test]
+    fn chromset_out_of_range_is_error() {
+        assert!("0-5".parse::<ChromosomeSet>().is_err());
+        assert!("20-25".parse::<ChromosomeSet>().is_err());
+        assert!("99".parse::<ChromosomeSet>().is_err());
     }
 
     #[test]


### PR DESCRIPTION
Adds `--chromosome <spec>` to `favor ingest`. Accepts `22`, `1,2,3`, `1-22`, or combinations like `1-22,X,Y,MT`. Records outside the set count as filtered contigs (same accounting as today's non-standard contig filter). Default behavior is unchanged when the flag is omitted.

Parser lives on a new `ChromosomeSet` type in `types.rs` — 25-bool bitset, reuses `Chromosome::from_str` for token validation. Named chromosomes can't appear in ranges (`X-Y` errors). Filtering happens at the `normalize_chrom` call site in `RecordContext::process_record`; both sequential and parallel paths are covered.

`cargo test --bin favor`: 292/292. `cargo clippy --bin favor --tests -- -D warnings`: clean.

Closes #86.