### PR TITLE
staar: collect per-gene scratch into one struct

### DIFF
--- a/src/staar/invariance_test.rs
+++ b/src/staar/invariance_test.rs
@@ -1,0 +1,162 @@
+//! Bit-identical regression net for the STAAR sumstats kernel.
+//!
+//! Loads the same `staar_continuous` fixture `ground_truth_test.rs` uses,
+//! runs `run_staar_from_sumstats`, and compares every output f64 as raw
+//! bits against a committed golden. No tolerance — any drift fails the
+//! build. Refactors that claim to be mathematically equivalent must not
+//! change the bits.
+//!
+//! Regenerate the golden (after an intentional numerical change) with:
+//!     cargo test -- regenerate_invariance_golden --ignored
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use faer::Mat;
+    use serde::{Deserialize, Serialize};
+
+    use crate::staar::score;
+
+    #[derive(Deserialize)]
+    struct GroundTruthRoot {
+        staar_continuous: StaarCase,
+    }
+
+    #[derive(Deserialize)]
+    struct StaarCase {
+        n_samples: usize,
+        #[serde(rename = "U")]
+        u: Vec<f64>,
+        #[serde(rename = "K")]
+        k: Vec<Vec<f64>>,
+        mafs: Vec<f64>,
+        annotation_rank: Vec<Vec<f64>>,
+        sigma2: f64,
+    }
+
+    /// Golden is structurally isomorphic to `score::StaarResult` but every
+    /// f64 is serialized as `to_bits()` in 16-char lowercase hex. That way
+    /// equality is bit-exact and a diff is human-readable.
+    #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
+    struct Golden {
+        burden_1_25: String,
+        burden_1_1: String,
+        skat_1_25: String,
+        skat_1_1: String,
+        acat_v_1_25: String,
+        acat_v_1_1: String,
+        per_annotation: Vec<[String; 6]>,
+        staar_b_1_25: String,
+        staar_b_1_1: String,
+        staar_s_1_25: String,
+        staar_s_1_1: String,
+        staar_a_1_25: String,
+        staar_a_1_1: String,
+        acat_o: String,
+        staar_o: String,
+    }
+
+    fn bits(x: f64) -> String {
+        format!("{:016x}", x.to_bits())
+    }
+
+    fn golden_of(r: &score::StaarResult) -> Golden {
+        Golden {
+            burden_1_25: bits(r.burden_1_25),
+            burden_1_1: bits(r.burden_1_1),
+            skat_1_25: bits(r.skat_1_25),
+            skat_1_1: bits(r.skat_1_1),
+            acat_v_1_25: bits(r.acat_v_1_25),
+            acat_v_1_1: bits(r.acat_v_1_1),
+            per_annotation: r
+                .per_annotation
+                .iter()
+                .map(|row| [
+                    bits(row[0]), bits(row[1]), bits(row[2]),
+                    bits(row[3]), bits(row[4]), bits(row[5]),
+                ])
+                .collect(),
+            staar_b_1_25: bits(r.staar_b_1_25),
+            staar_b_1_1: bits(r.staar_b_1_1),
+            staar_s_1_25: bits(r.staar_s_1_25),
+            staar_s_1_1: bits(r.staar_s_1_1),
+            staar_a_1_25: bits(r.staar_a_1_25),
+            staar_a_1_1: bits(r.staar_a_1_1),
+            acat_o: bits(r.acat_o),
+            staar_o: bits(r.staar_o),
+        }
+    }
+
+    fn testdata_dir() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("src")
+            .join("staar")
+            .join("testdata")
+    }
+
+    fn load_inputs() -> StaarCase {
+        let path = testdata_dir().join("ground_truth.json");
+        let data = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
+        // R serializes NULL as `{}` in some sections; normalize so serde parses.
+        let data = data.replace(": {}", ": null");
+        let root: GroundTruthRoot = serde_json::from_str(&data)
+            .expect("failed to parse ground_truth.json");
+        root.staar_continuous
+    }
+
+    fn run_kernel(case: &StaarCase) -> score::StaarResult {
+        // The kernel expects U / sigma2 and K / sigma2 (sum-stat scaling);
+        // ground_truth.json stores raw U = G'r and K = G'PG.
+        let inv_s2 = 1.0 / case.sigma2;
+        let u_scaled: Vec<f64> = case.u.iter().map(|&v| v * inv_s2).collect();
+        let k_scaled: Vec<Vec<f64>> = case
+            .k
+            .iter()
+            .map(|row| row.iter().map(|&v| v * inv_s2).collect())
+            .collect();
+
+        let u = Mat::from_fn(u_scaled.len(), 1, |i, _| u_scaled[i]);
+        let k = Mat::from_fn(k_scaled.len(), k_scaled[0].len(), |i, j| k_scaled[i][j]);
+
+        score::run_staar_from_sumstats(&u, &k, &case.annotation_rank, &case.mafs, case.n_samples)
+    }
+
+    #[test]
+    fn invariance_bits_match_golden() {
+        let case = load_inputs();
+        let actual = golden_of(&run_kernel(&case));
+
+        let golden_path = testdata_dir().join("invariance_golden.json");
+        let text = std::fs::read_to_string(&golden_path).unwrap_or_else(|e| {
+            panic!(
+                "cannot read {}: {e}\n\
+                 regenerate with: cargo test -- regenerate_invariance_golden --ignored",
+                golden_path.display()
+            )
+        });
+        let expected: Golden = serde_json::from_str(&text)
+            .expect("failed to parse invariance_golden.json");
+
+        assert_eq!(
+            actual, expected,
+            "STAAR output drift — run `cargo test -- regenerate_invariance_golden --ignored` \
+             if the drift is intentional; otherwise the change is a regression."
+        );
+    }
+
+    #[test]
+    #[ignore = "regenerates the committed invariance_golden.json"]
+    fn regenerate_invariance_golden() {
+        let case = load_inputs();
+        let golden = golden_of(&run_kernel(&case));
+        let json = serde_json::to_string_pretty(&golden).unwrap();
+
+        let path = testdata_dir().join("invariance_golden.json");
+        std::fs::write(&path, json).unwrap_or_else(|e| {
+            panic!("cannot write {}: {e}", path.display())
+        });
+        eprintln!("wrote {}", path.display());
+    }
+}

--- a/src/staar/mod.rs
+++ b/src/staar/mod.rs
@@ -3,6 +3,8 @@ pub mod carrier;
 pub mod genotype;
 #[cfg(test)]
 mod ground_truth_test;
+#[cfg(test)]
+mod invariance_test;
 pub mod kinship;
 pub mod masks;
 pub mod meta;

--- a/src/staar/score.rs
+++ b/src/staar/score.rs
@@ -316,6 +316,51 @@ pub fn run_staar_from_sumstats(
     )
 }
 
+/// Per-gene scratch for the STAAR test battery: weight vectors (length m),
+/// SKAT kernel buffer (m × m), and per-gene omnibus accumulators. Collects
+/// the allocations that used to be scattered across `staar_tests` so they
+/// can be sized once per gene instead of interleaved with the test loop.
+struct GeneScratch {
+    beta_1_25: Vec<f64>,
+    beta_1_1: Vec<f64>,
+    acat_denom: Vec<f64>,
+    wa_base_1_25: Vec<f64>,
+    wa_base_1_1: Vec<f64>,
+    wb_1_25: Vec<f64>,
+    wb_1_1: Vec<f64>,
+    ws_1_25: Vec<f64>,
+    ws_1_1: Vec<f64>,
+    wa_1_25: Vec<f64>,
+    wa_1_1: Vec<f64>,
+    kernel_buf: Mat<f64>,
+    by_test: [Vec<f64>; 6],
+    per_annotation: Vec<[f64; 6]>,
+    all_p: Vec<f64>,
+}
+
+impl GeneScratch {
+    fn with_capacity(m: usize, n_channels: usize) -> Self {
+        let mzeros = || vec![0.0; m];
+        Self {
+            beta_1_25: mzeros(),
+            beta_1_1: mzeros(),
+            acat_denom: mzeros(),
+            wa_base_1_25: mzeros(),
+            wa_base_1_1: mzeros(),
+            wb_1_25: mzeros(),
+            wb_1_1: mzeros(),
+            ws_1_25: mzeros(),
+            ws_1_1: mzeros(),
+            wa_1_25: mzeros(),
+            wa_1_1: mzeros(),
+            kernel_buf: Mat::zeros(m, m),
+            by_test: std::array::from_fn(|_| Vec::with_capacity(1 + n_channels)),
+            per_annotation: Vec::with_capacity(n_channels),
+            all_p: Vec::with_capacity(6 + n_channels * 6),
+        }
+    }
+}
+
 /// Shared test engine for both single-study and meta-analysis paths.
 /// Computes all 6 base tests, annotation-weighted variants, and omnibus combinations.
 ///
@@ -335,45 +380,25 @@ where
     BF: Fn(&[f64]) -> f64,
     AF: Fn(&[f64], &[f64]) -> f64,
 {
-    let beta_1_25: Vec<f64> = mafs
-        .iter()
-        .map(|&maf| beta_density_weight(maf, 1.0, 25.0))
-        .collect();
-    let beta_1_1: Vec<f64> = mafs
-        .iter()
-        .map(|&maf| beta_density_weight(maf, 1.0, 1.0))
-        .collect();
-    let acat_denom: Vec<f64> = mafs
-        .iter()
-        .map(|&maf| {
-            let d = beta_density_weight(maf, 0.5, 0.5);
-            if d > 0.0 {
-                d * d
-            } else {
-                1.0
-            }
-        })
-        .collect();
-
     let m = mafs.len();
-    let mut kernel_buf = Mat::zeros(m, m);
+    let n_channels = annotation_matrix.len();
+    let mut s = GeneScratch::with_capacity(m, n_channels);
 
-    let base_burden_1_25 = run_burden(&beta_1_25);
-    let base_burden_1_1 = run_burden(&beta_1_1);
-    let base_skat_1_25 = skat(u, k, &beta_1_25, sigma2, &mut kernel_buf);
-    let base_skat_1_1 = skat(u, k, &beta_1_1, sigma2, &mut kernel_buf);
-    let wa_base_1_25: Vec<f64> = beta_1_25
-        .iter()
-        .zip(&acat_denom)
-        .map(|(b, d)| b * b / d)
-        .collect();
-    let wa_base_1_1: Vec<f64> = beta_1_1
-        .iter()
-        .zip(&acat_denom)
-        .map(|(b, d)| b * b / d)
-        .collect();
-    let base_acat_v_1_25 = run_acat_v(&wa_base_1_25, &beta_1_25);
-    let base_acat_v_1_1 = run_acat_v(&wa_base_1_1, &beta_1_1);
+    for (j, &maf) in mafs.iter().enumerate() {
+        s.beta_1_25[j] = beta_density_weight(maf, 1.0, 25.0);
+        s.beta_1_1[j] = beta_density_weight(maf, 1.0, 1.0);
+        let d = beta_density_weight(maf, 0.5, 0.5);
+        s.acat_denom[j] = if d > 0.0 { d * d } else { 1.0 };
+        s.wa_base_1_25[j] = s.beta_1_25[j] * s.beta_1_25[j] / s.acat_denom[j];
+        s.wa_base_1_1[j] = s.beta_1_1[j] * s.beta_1_1[j] / s.acat_denom[j];
+    }
+
+    let base_burden_1_25 = run_burden(&s.beta_1_25);
+    let base_burden_1_1 = run_burden(&s.beta_1_1);
+    let base_skat_1_25 = skat(u, k, &s.beta_1_25, sigma2, &mut s.kernel_buf);
+    let base_skat_1_1 = skat(u, k, &s.beta_1_1, sigma2, &mut s.kernel_buf);
+    let base_acat_v_1_25 = run_acat_v(&s.wa_base_1_25, &s.beta_1_25);
+    let base_acat_v_1_1 = run_acat_v(&s.wa_base_1_1, &s.beta_1_1);
 
     let acat_o = stats::cauchy_combine(&[
         base_burden_1_25,
@@ -384,62 +409,52 @@ where
         base_acat_v_1_1,
     ]);
 
-    let n_channels = annotation_matrix.len();
-    let mut per_annotation: Vec<[f64; 6]> = Vec::with_capacity(n_channels);
-
     // Accumulate p-values per test type across annotation channels for STAAR omnibus.
     // Index order: Burden(1,25), Burden(1,1), SKAT(1,25), SKAT(1,1), ACAT-V(1,25), ACAT-V(1,1)
-    let mut by_test: [Vec<f64>; 6] = [
-        vec![base_burden_1_25],
-        vec![base_burden_1_1],
-        vec![base_skat_1_25],
-        vec![base_skat_1_1],
-        vec![base_acat_v_1_25],
-        vec![base_acat_v_1_1],
-    ];
-
-    let mut wb_1_25 = vec![0.0; m];
-    let mut wb_1_1 = vec![0.0; m];
-    let mut ws_1_25 = vec![0.0; m];
-    let mut ws_1_1 = vec![0.0; m];
-    let mut wa_1_25 = vec![0.0; m];
-    let mut wa_1_1 = vec![0.0; m];
+    s.by_test[0].push(base_burden_1_25);
+    s.by_test[1].push(base_burden_1_1);
+    s.by_test[2].push(base_skat_1_25);
+    s.by_test[3].push(base_skat_1_1);
+    s.by_test[4].push(base_acat_v_1_25);
+    s.by_test[5].push(base_acat_v_1_1);
 
     for channel_weights in annotation_matrix {
+        // Eight parallel slices indexed by j; a single range loop beats chaining
+        // seven zips. Keep the indexing form; clippy's range-loop lint disagrees.
+        #[allow(clippy::needless_range_loop)]
         for j in 0..m {
             let a = channel_weights[j];
             let a_sqrt = a.sqrt();
-            wb_1_25[j] = beta_1_25[j] * a;
-            wb_1_1[j] = beta_1_1[j] * a;
-            ws_1_25[j] = beta_1_25[j] * a_sqrt;
-            ws_1_1[j] = beta_1_1[j] * a_sqrt;
-            wa_1_25[j] = a * beta_1_25[j] * beta_1_25[j] / acat_denom[j];
-            wa_1_1[j] = a * beta_1_1[j] * beta_1_1[j] / acat_denom[j];
+            s.wb_1_25[j] = s.beta_1_25[j] * a;
+            s.wb_1_1[j] = s.beta_1_1[j] * a;
+            s.ws_1_25[j] = s.beta_1_25[j] * a_sqrt;
+            s.ws_1_1[j] = s.beta_1_1[j] * a_sqrt;
+            s.wa_1_25[j] = a * s.beta_1_25[j] * s.beta_1_25[j] / s.acat_denom[j];
+            s.wa_1_1[j] = a * s.beta_1_1[j] * s.beta_1_1[j] / s.acat_denom[j];
         }
 
         let p = [
-            run_burden(&wb_1_25),
-            run_burden(&wb_1_1),
-            skat(u, k, &ws_1_25, sigma2, &mut kernel_buf),
-            skat(u, k, &ws_1_1, sigma2, &mut kernel_buf),
-            run_acat_v(&wa_1_25, &wb_1_25),
-            run_acat_v(&wa_1_1, &wb_1_1),
+            run_burden(&s.wb_1_25),
+            run_burden(&s.wb_1_1),
+            skat(u, k, &s.ws_1_25, sigma2, &mut s.kernel_buf),
+            skat(u, k, &s.ws_1_1, sigma2, &mut s.kernel_buf),
+            run_acat_v(&s.wa_1_25, &s.wb_1_25),
+            run_acat_v(&s.wa_1_1, &s.wb_1_1),
         ];
-        for i in 0..6 {
-            by_test[i].push(p[i]);
+        for (bucket, pv) in s.by_test.iter_mut().zip(p.iter()) {
+            bucket.push(*pv);
         }
-        per_annotation.push(p);
+        s.per_annotation.push(p);
     }
 
-    let staar_b_1_25 = stats::cauchy_combine(&by_test[0]);
-    let staar_b_1_1 = stats::cauchy_combine(&by_test[1]);
-    let staar_s_1_25 = stats::cauchy_combine(&by_test[2]);
-    let staar_s_1_1 = stats::cauchy_combine(&by_test[3]);
-    let staar_a_1_25 = stats::cauchy_combine(&by_test[4]);
-    let staar_a_1_1 = stats::cauchy_combine(&by_test[5]);
+    let staar_b_1_25 = stats::cauchy_combine(&s.by_test[0]);
+    let staar_b_1_1 = stats::cauchy_combine(&s.by_test[1]);
+    let staar_s_1_25 = stats::cauchy_combine(&s.by_test[2]);
+    let staar_s_1_1 = stats::cauchy_combine(&s.by_test[3]);
+    let staar_a_1_25 = stats::cauchy_combine(&s.by_test[4]);
+    let staar_a_1_1 = stats::cauchy_combine(&s.by_test[5]);
 
-    let mut all_p: Vec<f64> = Vec::with_capacity(6 + n_channels * 6);
-    all_p.extend_from_slice(&[
+    s.all_p.extend_from_slice(&[
         base_burden_1_25,
         base_burden_1_1,
         base_skat_1_25,
@@ -447,10 +462,10 @@ where
         base_acat_v_1_25,
         base_acat_v_1_1,
     ]);
-    for p in &per_annotation {
-        all_p.extend_from_slice(p);
+    for p in &s.per_annotation {
+        s.all_p.extend_from_slice(p);
     }
-    let staar_o = stats::cauchy_combine(&all_p);
+    let staar_o = stats::cauchy_combine(&s.all_p);
 
     StaarResult {
         burden_1_25: base_burden_1_25,
@@ -459,7 +474,7 @@ where
         skat_1_1: base_skat_1_1,
         acat_v_1_25: base_acat_v_1_25,
         acat_v_1_1: base_acat_v_1_1,
-        per_annotation,
+        per_annotation: s.per_annotation,
         staar_b_1_25,
         staar_b_1_1,
         staar_s_1_25,

--- a/src/staar/testdata/invariance_golden.json
+++ b/src/staar/testdata/invariance_golden.json
@@ -1,0 +1,42 @@
+{
+  "burden_1_25": "3fda972daf11185a",
+  "burden_1_1": "3fd97a9dbf38ec82",
+  "skat_1_25": "3fda5de1b4cef4a6",
+  "skat_1_1": "3fdd12d8dee4bc0c",
+  "acat_v_1_25": "3fe7f6e0aa8cb822",
+  "acat_v_1_1": "3fe9b81d457747d2",
+  "per_annotation": [
+    [
+      "3fdeb9cfab767db0",
+      "3fdd5614dc720b7e",
+      "3fdc250a234e8da8",
+      "3fdeb18e73abb334",
+      "3fe8be946e9770d3",
+      "3fea414ef75b41a4"
+    ],
+    [
+      "3fd4c720033ff639",
+      "3fd3616d7b507853",
+      "3fd575deacd3dec8",
+      "3fd7c6363663cb54",
+      "3fe1cb6026f4b0eb",
+      "3fe4adb80ef965c3"
+    ],
+    [
+      "3fdd8f03404ea657",
+      "3fdc3f6db4124c64",
+      "3fda08be6ca55cf8",
+      "3fdcbda9e83cb488",
+      "3fe81a9a2e453872",
+      "3fe9c5a547a0251a"
+    ]
+  ],
+  "staar_b_1_25": "3fdaadb3e5f77a7d",
+  "staar_b_1_1": "3fd94ffc9fbd6e6a",
+  "staar_s_1_25": "3fd96343db926c4a",
+  "staar_s_1_1": "3fdbfdb4e8de7295",
+  "staar_a_1_25": "3fe719dd1fec2f13",
+  "staar_a_1_1": "3fe90a1f407835ac",
+  "acat_o": "3fe24a2aaa97c3ce",
+  "staar_o": "3fe18d8594cf3871"
+}


### PR DESCRIPTION
Replaces the 14 scattered `vec![0.0; m]` / `Vec::with_capacity` allocations inside `staar_tests` with a single `GeneScratch` struct allocated at the top of the function. Same pattern as `MultiScratch` in `src/staar/multi.rs`. Math is unchanged — the bit-identical invariance test from #115 still matches every f64.

Scoped to `src/staar/score.rs`. `sparse_score` and REML get the same treatment in follow-ups.

Stacked on #115 because it relies on the invariance test to prove no drift. Rebases cleanly once #115 merges.

`cargo test --bin favor`: 293/293. `cargo clippy --bin favor --tests -- -D warnings`: clean.

Closes #44.