### PR TITLE
staar: lock the 11 annotation-channel catalog at preflight

### DIFF
--- a/docs/staar.md
+++ b/docs/staar.md
@@ -120,6 +120,32 @@ Reading `U`, `K`: think signal and noise. `U[v]` = how much variant `v`
 lines up with the residuals. Big `|U|` = suspicious. `K` = how much `U`
 could wiggle by chance given the covariates already used.
 
+### Annotation channel catalog
+
+The eleven channels are fixed. Changing names, dropping one, or reordering
+silently changes STAAR-O; `favor staar` validates the annotation parquet
+against this catalog at startup and errors loud if any channel is missing.
+
+```text
+order   column name              source
+─────   ──────────────────────   ────────────────────────────────
+  1     w_cadd                   CADD-Phred (main annotation)
+  2     w_linsight               LINSIGHT
+  3     w_fathmm_xf              fathmm-XF
+  4     w_apc_epi_active         aPC epigenetics, active mark
+  5     w_apc_epi_repressed      aPC epigenetics, repressed mark
+  6     w_apc_epi_transcription  aPC epigenetics, transcription
+  7     w_apc_conservation       aPC conservation (v2)
+  8     w_apc_protein_function   aPC protein function (v3)
+  9     w_apc_local_nd           aPC local nucleotide diversity (v3)
+ 10     w_apc_mutation_density   aPC mutation density
+ 11     w_apc_tf                 aPC transcription-factor binding
+```
+
+Extra `w_*` columns are allowed — reads happen by name, so added channels
+don't shift any existing index. Missing columns fail the preflight with
+the column names called out.
+
 ### Test battery
 
 Three test shapes × two β-weight shapes = six base tests. Each runs against

--- a/src/staar/pipeline.rs
+++ b/src/staar/pipeline.rs
@@ -446,10 +446,14 @@ impl<'a> StaarPipeline<'a> {
 
         // Typed tier check: STAAR needs all 11 annotation weight columns.
         // `supports` errors if the set is not annotated, or if any weight
-        // column is missing for the tier it was annotated against.
+        // column is missing for the tier it was annotated against. The
+        // `require_staar_weight_catalog` call below additionally confirms
+        // the parquet actually has each column by name — catches partial
+        // writes and out-of-band regeneration the tier metadata misses.
         let ann_vs = VariantSet::open(annotations)?;
         let weight_cols: Vec<crate::column::Col> = STAAR_WEIGHTS.to_vec();
         ann_vs.supports(&weight_cols)?;
+        ann_vs.require_staar_weight_catalog()?;
 
         // Raw annotation column contract.
         let contract = ColumnContract {

--- a/src/store/list/mod.rs
+++ b/src/store/list/mod.rs
@@ -115,6 +115,30 @@ impl VariantSet {
         }
         Ok(tier)
     }
+
+    /// Fail loud if the variant set's schema is missing any of the 11 STAAR
+    /// weight channels. The tier check in `supports` only verifies metadata;
+    /// this check verifies the parquet actually has each column by name.
+    /// Catches partial writes, renamed columns, or out-of-band regeneration.
+    pub fn require_staar_weight_catalog(&self) -> Result<(), CohortError> {
+        let have = self.columns();
+        let missing: Vec<&str> = crate::column::STAAR_WEIGHTS
+            .iter()
+            .map(|c| c.as_str())
+            .filter(|name| !have.iter().any(|h| h == name))
+            .collect();
+        if missing.is_empty() {
+            return Ok(());
+        }
+        Err(CohortError::DataMissing(format!(
+            "Annotation set at {} is missing {} of the 11 STAAR weight channels:\n  {}\n\
+             The channel catalog is fixed — all 11 must be present for STAAR-O to match R.\n\
+             Re-run: `favor annotate --full` against a full-tier FAVOR source.",
+            self.root.display(),
+            missing.len(),
+            missing.join(", "),
+        )))
+    }
 }
 
 pub struct VariantSetWriter {
@@ -317,5 +341,62 @@ pub fn parquet_column_names(path: &Path) -> Result<Vec<String>, CohortError> {
         .iter()
         .map(|f| f.name().to_string())
         .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vs_with_columns(cols: Vec<String>) -> VariantSet {
+        VariantSet {
+            root: PathBuf::from("/tmp/not-a-real-set"),
+            meta: VariantMeta {
+                version: 1,
+                join_key: JoinKey::ChromPosRefAlt,
+                variant_count: 0,
+                per_chrom: HashMap::new(),
+                columns: cols,
+                source: "test".into(),
+                kind: Some(VariantSetKind::Annotated { tier: Tier::Full }),
+            },
+        }
+    }
+
+    #[test]
+    fn catalog_passes_when_all_11_weights_present() {
+        let cols: Vec<String> = crate::column::STAAR_WEIGHTS
+            .iter()
+            .map(|c| c.as_str().to_string())
+            .collect();
+        let vs = vs_with_columns(cols);
+        assert!(vs.require_staar_weight_catalog().is_ok());
+    }
+
+    #[test]
+    fn catalog_errors_on_missing_channel() {
+        // Drop one weight and a non-weight column; only the weight should be flagged.
+        let cols: Vec<String> = crate::column::STAAR_WEIGHTS
+            .iter()
+            .skip(1)
+            .map(|c| c.as_str().to_string())
+            .chain(["position".into(), "ref".into()])
+            .collect();
+        let err = vs_with_columns(cols).require_staar_weight_catalog().unwrap_err();
+        let msg = err.to_string();
+        let missing_name = crate::column::STAAR_WEIGHTS[0].as_str();
+        assert!(msg.contains(missing_name), "missing name should appear: {msg}");
+    }
+
+    #[test]
+    fn catalog_accepts_extras() {
+        // Extras beyond the 11 weights are allowed — downstream reads by name,
+        // so ordering or extras don't shift anything.
+        let mut cols: Vec<String> = crate::column::STAAR_WEIGHTS
+            .iter()
+            .map(|c| c.as_str().to_string())
+            .collect();
+        cols.push("w_future_channel".into());
+        assert!(vs_with_columns(cols).require_staar_weight_catalog().is_ok());
+    }
 }
 


### PR DESCRIPTION
Before STAAR runs, verify the annotation variant set actually has all eleven weight columns by name. The existing `supports()` check only consults tier metadata, which drifts from the parquet schema if anyone regenerates one without the other. The catch-all is a missing-column error naming the missing channel.

Extras are allowed — downstream reads by name, so adding a future `w_*` channel never shifts any index. Only missing channels fail the preflight.

The eleven-channel catalog is now documented in `docs/staar.md` with source attribution. Three unit tests cover present / missing / extras paths.

`cargo test --bin favor`: 296/296. `cargo clippy --bin favor --tests -- -D warnings`: clean.

Closes #104.