### PR TITLE
staar: wire --individual producer

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -233,7 +233,7 @@ pub enum Command {
         #[arg(long, default_value = "2000")]
         window_size: u32,
 
-        /// Run per-variant individual score tests (no-op; producer not yet wired).
+        /// Run per-variant individual score tests. Gaussian + unrelated samples only.
         #[arg(long)]
         individual: bool,
 

--- a/src/staar/carrier/sparse_score.rs
+++ b/src/staar/carrier/sparse_score.rs
@@ -536,6 +536,104 @@ pub fn slice_sumstats_flat(
     Mat::from_fn(s, s, |i, j| k_flat[indices[i] * m + indices[j]])
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct IndividualScore {
+    pub score: f64,
+    pub score_se: f64,
+    pub est: f64,
+    pub est_se: f64,
+    pub pvalue: f64,
+    pub mac: u32,
+    pub alt_af: f64,
+}
+
+/// Score-test one variant under a gaussian, unrelated, single-trait null.
+/// Mirrors R STAARpipeline `Individual_Score_Test_denseGRM.cpp`. GMMAT's
+/// projection absorbs 1/σ², so `Score` and `Cov` here are the scaled
+/// forms R returns, not the raw `G'r`. Binary / kinship / multi paths are
+/// gated out by the caller and live in follow-up issues.
+pub fn individual_score_test(
+    carriers: &CarrierList,
+    analysis: &AnalysisVectors,
+) -> IndividualScore {
+    debug_assert!(analysis.kinship.is_none(), "kinship path not wired");
+    debug_assert!(
+        analysis.working_weights.is_empty(),
+        "binary path not wired",
+    );
+    let k = analysis.k;
+
+    let mut score_raw = 0.0f64;
+    let mut gtg = 0.0f64;
+    let mut gtx = vec![0.0f64; k];
+    let mut total_dosage = 0.0f64;
+    let mut mac: u32 = 0;
+
+    for &CarrierEntry { sample_idx, dosage } in &carriers.entries {
+        if dosage == 255 {
+            continue;
+        }
+        let Some(pi) = analysis.vcf_to_pheno[sample_idx as usize] else {
+            continue;
+        };
+        let pi = pi as usize;
+        let d = dosage as f64;
+        score_raw += d * analysis.residuals[pi];
+        gtg += d * d;
+        total_dosage += d;
+        mac = mac.saturating_add(dosage as u32);
+        let row = &analysis.x_row_major[pi * k..(pi + 1) * k];
+        for c in 0..k {
+            gtx[c] += d * row[c];
+        }
+    }
+
+    let mut correction = 0.0f64;
+    for i in 0..k {
+        let row = &analysis.xtx_inv[i * k..(i + 1) * k];
+        let mut inner = 0.0f64;
+        for j in 0..k {
+            inner += row[j] * gtx[j];
+        }
+        correction += gtx[i] * inner;
+    }
+    let k_jj = gtg - correction;
+    let sigma2 = analysis.sigma2;
+    let cov = k_jj / sigma2;
+
+    let (score, score_se, est, est_se, pvalue) = if cov.is_finite() && cov > 0.0 {
+        let score_r = score_raw / sigma2;
+        let se = cov.sqrt();
+        let t = score_r * score_r / cov;
+        (
+            score_r,
+            se,
+            score_raw / k_jj,
+            1.0 / se,
+            crate::staar::score::chisq1_pvalue(t),
+        )
+    } else {
+        // R sets all output fields to zero when Cov[i,i] == 0.
+        (0.0, 0.0, 0.0, 0.0, 1.0)
+    };
+
+    let alt_af = if analysis.n_pheno > 0 {
+        total_dosage / (2.0 * analysis.n_pheno as f64)
+    } else {
+        0.0
+    };
+
+    IndividualScore {
+        score,
+        score_se,
+        est,
+        est_se,
+        pvalue,
+        mac,
+        alt_af,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -609,6 +707,46 @@ mod tests {
                 let expected = k_dense[(i, j)] * inv_s2;
                 let diff = (expected - k_sparse[(i, j)]).abs();
                 assert!(diff < 1e-10, "K[{i},{j}]: expected={expected} got={} diff={diff}", k_sparse[(i, j)]);
+            }
+        }
+
+        // Individual-variant test must match R STAARpipeline
+        // `Individual_Score_Test_denseGRM.cpp` convention:
+        //   Score    = G'r_raw / σ²
+        //   Cov[i,i] = K[i,i] / σ²
+        //   Score_se = sqrt(Cov[i,i])
+        //   Est      = G'r_raw / K
+        //   Est_se   = 1 / Score_se
+        for j in 0..m {
+            let got = individual_score_test(&carriers[j], &analysis);
+            let raw_score = u_dense[(j, 0)];
+            let k_j = k_dense[(j, j)];
+            let expected_score = raw_score / null.sigma2;
+            let expected_cov = k_j / null.sigma2;
+            assert!(
+                (got.score - expected_score).abs() < 1e-10,
+                "variant {j}: Score {} vs {}",
+                got.score, expected_score,
+            );
+            if expected_cov > 0.0 {
+                let expected_se = expected_cov.sqrt();
+                assert!(
+                    (got.score_se - expected_se).abs() < 1e-10,
+                    "variant {j}: Score_se {} vs {}",
+                    got.score_se, expected_se,
+                );
+                let expected_est = raw_score / k_j;
+                assert!(
+                    (got.est - expected_est).abs() < 1e-10,
+                    "variant {j}: Est {} vs {}",
+                    got.est, expected_est,
+                );
+                let expected_est_se = 1.0 / expected_se;
+                assert!(
+                    (got.est_se - expected_est_se).abs() < 1e-10,
+                    "variant {j}: Est_se {} vs {}",
+                    got.est_se, expected_est_se,
+                );
             }
         }
     }

--- a/src/staar/output.rs
+++ b/src/staar/output.rs
@@ -23,8 +23,6 @@ use crate::column::{Col, STAAR_WEIGHTS};
 use crate::error::CohortError;
 use crate::output::Output;
 use crate::store::manifest::{fsync_parent, tmp_path, write_atomic};
-use crate::types::AnnotatedVariant;
-
 use super::multi::MultiNullContinuous;
 use super::{GeneResult, MaskType, TraitType};
 
@@ -77,41 +75,66 @@ where
     Ok(())
 }
 
+#[derive(Debug, Clone)]
+pub struct IndividualRow {
+    pub chromosome: String,
+    pub position: u32,
+    pub ref_allele: Box<str>,
+    pub alt_allele: Box<str>,
+    pub maf: f64,
+    pub alt_af: f64,
+    pub n: u32,
+    pub mac: u32,
+    pub pvalue: f64,
+    pub pvalue_log10: f64,
+    pub score: f64,
+    pub score_se: f64,
+    pub est: f64,
+    pub est_se: f64,
+}
+
 pub fn write_individual_results(
-    pvals: &[(usize, f64)],
-    variants: &[AnnotatedVariant],
+    rows: &[IndividualRow],
     output_dir: &Path,
     out: &dyn Output,
 ) -> Result<(), CohortError> {
     let out_path = output_dir.join("individual.parquet");
-    let n = pvals.len();
+    let n = rows.len();
 
-    let mut sorted: Vec<(usize, f64)> = pvals.to_vec();
-    sorted.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+    // R orders by POS ascending before returning (Individual_Analysis.R:450).
+    let mut sorted: Vec<IndividualRow> = rows.to_vec();
+    sorted.sort_by_key(|r| r.position);
 
     let mut b_chrom = StringBuilder::with_capacity(n, n * 2);
     let mut b_pos = Int32Builder::with_capacity(n);
     let mut b_ref = StringBuilder::with_capacity(n, n * 4);
     let mut b_alt = StringBuilder::with_capacity(n, n * 4);
+    let mut b_alt_af = Float64Builder::with_capacity(n);
     let mut b_maf = Float64Builder::with_capacity(n);
-    let mut b_gene = StringBuilder::with_capacity(n, n * 8);
-    let mut b_region = StringBuilder::with_capacity(n, n * 8);
-    let mut b_consequence = StringBuilder::with_capacity(n, n * 8);
-    let mut b_cadd = Float64Builder::with_capacity(n);
+    let mut b_n = UInt32Builder::with_capacity(n);
+    let mut b_mac = UInt32Builder::with_capacity(n);
     let mut b_pvalue = Float64Builder::with_capacity(n);
+    let mut b_pvalue_log10 = Float64Builder::with_capacity(n);
+    let mut b_score = Float64Builder::with_capacity(n);
+    let mut b_score_se = Float64Builder::with_capacity(n);
+    let mut b_est = Float64Builder::with_capacity(n);
+    let mut b_est_se = Float64Builder::with_capacity(n);
 
-    for &(idx, pval) in &sorted {
-        let v = &variants[idx];
-        b_chrom.append_value(v.chromosome.label());
-        b_pos.append_value(v.position as i32);
-        b_ref.append_value(&v.ref_allele);
-        b_alt.append_value(&v.alt_allele);
-        b_maf.append_value(v.maf);
-        b_gene.append_value(&v.gene_name);
-        b_region.append_value(v.annotation.region_type.as_str());
-        b_consequence.append_value(v.annotation.consequence.as_str());
-        b_cadd.append_value(v.annotation.cadd_phred);
-        b_pvalue.append_value(pval);
+    for row in &sorted {
+        b_chrom.append_value(&row.chromosome);
+        b_pos.append_value(row.position as i32);
+        b_ref.append_value(&row.ref_allele);
+        b_alt.append_value(&row.alt_allele);
+        b_alt_af.append_value(row.alt_af);
+        b_maf.append_value(row.maf);
+        b_n.append_value(row.n);
+        b_mac.append_value(row.mac);
+        b_pvalue.append_value(row.pvalue);
+        b_pvalue_log10.append_value(row.pvalue_log10);
+        b_score.append_value(row.score);
+        b_score_se.append_value(row.score_se);
+        b_est.append_value(row.est);
+        b_est_se.append_value(row.est_se);
     }
 
     let schema = Arc::new(Schema::new(vec![
@@ -119,24 +142,32 @@ pub fn write_individual_results(
         Field::new(Col::Position.as_str(), DataType::Int32, false),
         Field::new(Col::RefAllele.as_str(), DataType::Utf8, false),
         Field::new(Col::AltAllele.as_str(), DataType::Utf8, false),
+        Field::new("ALT_AF", DataType::Float64, false),
         Field::new(Col::Maf.as_str(), DataType::Float64, false),
-        Field::new(Col::GeneName.as_str(), DataType::Utf8, false),
-        Field::new(Col::RegionType.as_str(), DataType::Utf8, false),
-        Field::new(Col::Consequence.as_str(), DataType::Utf8, false),
-        Field::new(Col::CaddPhred.as_str(), DataType::Float64, false),
+        Field::new("N", DataType::UInt32, false),
+        Field::new("MAC", DataType::UInt32, false),
         Field::new("pvalue", DataType::Float64, false),
+        Field::new("pvalue_log10", DataType::Float64, false),
+        Field::new("Score", DataType::Float64, false),
+        Field::new("Score_se", DataType::Float64, false),
+        Field::new("Est", DataType::Float64, false),
+        Field::new("Est_se", DataType::Float64, false),
     ]));
     let columns: Vec<ArrayRef> = vec![
         Arc::new(b_chrom.finish()),
         Arc::new(b_pos.finish()),
         Arc::new(b_ref.finish()),
         Arc::new(b_alt.finish()),
+        Arc::new(b_alt_af.finish()),
         Arc::new(b_maf.finish()),
-        Arc::new(b_gene.finish()),
-        Arc::new(b_region.finish()),
-        Arc::new(b_consequence.finish()),
-        Arc::new(b_cadd.finish()),
+        Arc::new(b_n.finish()),
+        Arc::new(b_mac.finish()),
         Arc::new(b_pvalue.finish()),
+        Arc::new(b_pvalue_log10.finish()),
+        Arc::new(b_score.finish()),
+        Arc::new(b_score_se.finish()),
+        Arc::new(b_est.finish()),
+        Arc::new(b_est_se.finish()),
     ];
     let batch = RecordBatch::try_new(schema.clone(), columns)
         .map_err(|e| CohortError::Resource(format!("Arrow batch: {e}")))?;
@@ -156,11 +187,11 @@ pub fn write_individual_results(
         Ok(())
     })?;
 
-    let n_sig = pvals.iter().filter(|(_, p)| *p < 5e-8).count();
+    let n_sig = rows.iter().filter(|r| r.pvalue < 5e-8).count();
     out.success(&format!(
         "  individual -> {} variants, {} genome-wide significant",
-        pvals.len(),
-        n_sig
+        rows.len(),
+        n_sig,
     ));
     Ok(())
 }

--- a/src/staar/pipeline.rs
+++ b/src/staar/pipeline.rs
@@ -175,7 +175,7 @@ impl StaarConfig {
 
 pub struct ScoringOutput {
     pub results: ResultSet,
-    pub individual_pvals: Vec<(usize, f64)>,
+    pub individual: Vec<crate::staar::output::IndividualRow>,
 }
 
 struct PhenoStageOut {
@@ -327,13 +327,12 @@ impl<'a> StaarPipeline<'a> {
         // through the cohort handle. Hold the result in a local so the
         // WriteResults stage doesn't trigger a second walk.
         let cohort = self.cohort();
-        let variants = load_rare_variants(&cohort, &store.manifest, self.config.maf_cutoff)?;
-        let n_rare = variants.len() as i64;
+        let n_rare = load_rare_variants(&cohort, &store.manifest, self.config.maf_cutoff)?
+            .len() as i64;
 
         self.stage(Stage::WriteResults, |p| {
             p.stage_write_results(
                 &scoring,
-                &variants,
                 &null_model,
                 pheno.trait_type,
                 pheno.n,
@@ -768,7 +767,7 @@ impl<'a> StaarPipeline<'a> {
         )?;
         Ok(ScoringOutput {
             results,
-            individual_pvals: Vec::new(),
+            individual: Vec::new(),
         })
     }
 
@@ -926,8 +925,14 @@ impl<'a> StaarPipeline<'a> {
             cache_dir,
             ancestry,
             spa_active: self.config.spa && trait_type == TraitType::Binary,
+            // Single-trait gaussian no-kinship path only in this build.
+            // Binary / kinship / multi land in follow-ups.
+            individual: self.config.individual
+                && trait_type == TraitType::Continuous
+                && !self.config.has_kinship(),
+            individual_mac_cutoff: 20,
         };
-        let (results, individual_pvals) = scoring::run_score_tests(
+        let (results, individual) = scoring::run_score_tests(
             &self.cohort(),
             &store.manifest,
             &request,
@@ -936,14 +941,13 @@ impl<'a> StaarPipeline<'a> {
         )?;
         Ok(ScoringOutput {
             results,
-            individual_pvals,
+            individual,
         })
     }
 
     fn stage_write_results(
         &mut self,
         scoring: &ScoringOutput,
-        variants: &[AnnotatedVariant],
         null_model: &NullModel,
         trait_type: TraitType,
         n: usize,
@@ -957,8 +961,8 @@ impl<'a> StaarPipeline<'a> {
             ))
         })?;
 
-        if self.config.individual && !scoring.individual_pvals.is_empty() {
-            write_individual_results(&scoring.individual_pvals, variants, &results_dir, self.out)?;
+        if self.config.individual && !scoring.individual.is_empty() {
+            write_individual_results(&scoring.individual, &results_dir, self.out)?;
         }
 
         write_results(

--- a/src/staar/score.rs
+++ b/src/staar/score.rs
@@ -265,7 +265,7 @@ fn acat_v(
 /// t ≈ 2700. Past that we floor at the smallest positive double so the
 /// downstream Cauchy combination sees a strictly positive p-value instead
 /// of poisoning the omnibus with an exact zero.
-fn chisq1_pvalue(t: f64) -> f64 {
+pub(crate) fn chisq1_pvalue(t: f64) -> f64 {
     if t <= 0.0 || !t.is_finite() {
         return 1.0;
     }

--- a/src/staar/scoring.rs
+++ b/src/staar/scoring.rs
@@ -48,6 +48,13 @@ pub struct ScoringRequest<'a> {
     pub cache_dir: &'a Path,
     pub ancestry: Option<&'a AncestryInfo>,
     pub spa_active: bool,
+    /// Emit per-variant score-test rows alongside mask/window results.
+    /// Matches R STAARpipeline's `Individual_Analysis` output (single-trait
+    /// gaussian no-kinship path only in this build).
+    pub individual: bool,
+    /// Minor-allele-count threshold for individual analysis. Matches R's
+    /// `mac_cutoff` (default 20 in `Individual_Analysis.R`).
+    pub individual_mac_cutoff: u32,
 }
 
 /// Compiled mask plan: gene predicates + window/scang flags + result-vector
@@ -141,17 +148,18 @@ impl<'v> ChromCtx<'v> {
 }
 
 /// Public entry point: score every chromosome in `manifest` and return
-/// per-mask gene/window result vectors plus individual p-values.
+/// per-mask gene/window result vectors plus per-variant individual rows.
 pub fn run_score_tests(
     cohort: &CohortHandle<'_>,
     manifest: &CohortManifest,
     request: &ScoringRequest<'_>,
     analysis: &AnalysisVectors,
     out: &dyn Output,
-) -> Result<(ResultSet, Vec<(usize, f64)>), CohortError> {
+) -> Result<(ResultSet, Vec<crate::staar::output::IndividualRow>), CohortError> {
     out.status("Running score tests (carrier-indexed sparse)...");
 
     let mut plan = MaskPlan::build(request.mask_categories, out);
+    let mut individual_rows: Vec<crate::staar::output::IndividualRow> = Vec::new();
 
     // `score_one_window` always takes the cached-U/K path; SPA on windows
     // isn't wired yet. Warn once so --spa users know their window p-values
@@ -184,10 +192,84 @@ pub fn run_score_tests(
         if plan.has_window_work() {
             score_chrom_windows(&chrom_ctx, request, analysis, &mut plan, out);
         }
+
+        if request.individual {
+            score_chrom_individual(&chrom_ctx, request, analysis, &mut individual_rows)?;
+        }
     }
 
-    // `--individual` producer not yet wired — see ScoringOutput.individual_pvals.
-    Ok((plan.results, Vec::new()))
+    Ok((plan.results, individual_rows))
+}
+
+/// Per-variant score test for every variant whose MAC clears `mac_cutoff`.
+/// Mirrors R STAARpipeline `Individual_Analysis` on the gaussian-unrelated
+/// path. Writer re-sorts by position to match R's final `order(results[,2])`.
+fn score_chrom_individual(
+    chrom_ctx: &ChromCtx<'_>,
+    request: &ScoringRequest<'_>,
+    analysis: &AnalysisVectors,
+    rows: &mut Vec<crate::staar::output::IndividualRow>,
+) -> Result<(), CohortError> {
+    use crate::store::cohort::types::VariantVcf;
+
+    let index = chrom_ctx.view.index()?;
+    let entries = index.all_entries();
+    let n_pheno = analysis.n_pheno as f64;
+    let mac_cutoff = request.individual_mac_cutoff;
+    let chrom_label = chrom_ctx.chrom.label();
+
+    // R `Individual_Analysis.R:324`: MAF > (mac_cutoff − 0.5) / (2 n).
+    let maf_floor = (mac_cutoff as f64 - 0.5) / (2.0 * n_pheno);
+
+    let mut passing: Vec<(u32, &crate::store::cohort::variants::VariantIndexEntry)> =
+        Vec::with_capacity(entries.len() / 100);
+    for (vcf, entry) in entries.iter().enumerate() {
+        if entry.maf > maf_floor {
+            passing.push((vcf as u32, entry));
+        }
+    }
+    if passing.is_empty() {
+        return Ok(());
+    }
+
+    // `all_entries` is vcf-ordered, so `passing` is already sorted as
+    // `carriers_batch` requires for a single sequential mmap walk.
+    let vcfs: Vec<VariantVcf> = passing.iter().map(|(v, _)| VariantVcf(*v)).collect();
+    let batch = chrom_ctx.view.carriers_batch(&vcfs)?;
+
+    let mut chrom_rows: Vec<crate::staar::output::IndividualRow> = passing
+        .par_iter()
+        .zip(batch.entries.par_iter())
+        .map(|(&(_vcf, entry), carriers)| {
+            let result = crate::staar::carrier::sparse_score::individual_score_test(
+                carriers, analysis,
+            );
+            let pvalue_log10 = if result.pvalue > 0.0 {
+                -result.pvalue.log10()
+            } else {
+                f64::INFINITY
+            };
+            crate::staar::output::IndividualRow {
+                chromosome: chrom_label.clone(),
+                position: entry.position,
+                ref_allele: entry.ref_allele.clone(),
+                alt_allele: entry.alt_allele.clone(),
+                maf: entry.maf,
+                alt_af: result.alt_af,
+                n: analysis.n_pheno as u32,
+                mac: result.mac,
+                pvalue: result.pvalue,
+                pvalue_log10,
+                score: result.score,
+                score_se: result.score_se,
+                est: result.est,
+                est_se: result.est_se,
+            }
+        })
+        .collect();
+
+    rows.append(&mut chrom_rows);
+    Ok(())
 }
 
 /// All quantities a single gene needs for mask scoring, in a single


### PR DESCRIPTION
Wires the per-variant score test stub into a real genome-wide producer. Mirrors R STAARpipeline `Individual_Score_Test_denseGRM.cpp` exactly — not just on the p-value but on the reported Score / Score_se / Est / Est_se columns, which in GMMAT's convention absorb one factor of σ² relative to the raw `G'r` (P = (I − H)/σ²).

Scope: gaussian unrelated single-trait. Binary / SPA, kinship (sparse + dense), and multi-trait paths are gated at `ScoringRequest` construction; the kernel debug-asserts those inputs stay out. Output schema matches R: `CHR, POS, REF, ALT, ALT_AF, MAF, N, MAC, pvalue, pvalue_log10, Score, Score_se, Est, Est_se`, sorted by position.

Producer runs in parallel across variants per chromosome via rayon, on top of a single sequential `sparse_g.bin` walk from `carriers_batch`. Unit test asserts the kernel matches a dense reference on all four reported columns.

`cargo test --bin favor`: 297/297. `cargo clippy --bin favor --tests -- -D warnings`: clean.

Closes #108.