### PR TITLE
staar: drop unused MaskCategory::Custom

### DIFF
--- a/docs/staar.md
+++ b/docs/staar.md
@@ -213,7 +213,6 @@ noncoding        upstream, downstream, UTR, promoter_CAGE, promoter_   region_ty
                  DHS, enhancer_CAGE, enhancer_DHS, ncRNA                flags
 sliding-window   fixed-width chunks (default 2 kb, step 2 kb)          positional
 scang            variable-width chunks, L ∈ [lmin, lmax] variants      positional (data-adaptive)
-custom           user BED (not yet wired)                              user-supplied
 ```
 
 ### Speed

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -23,7 +23,7 @@ pub fn parse_mask_categories(masks: &[String]) -> Result<Vec<MaskCategory>, Coho
         .map(|s| {
             s.parse::<MaskCategory>().map_err(|_| {
                 CohortError::Input(format!(
-                    "Unknown mask '{s}'. Available: coding, noncoding, sliding-window, scang, custom"
+                    "Unknown mask '{s}'. Available: coding, noncoding, sliding-window, scang"
                 ))
             })
         })

--- a/src/staar/mod.rs
+++ b/src/staar/mod.rs
@@ -78,7 +78,6 @@ pub enum MaskCategory {
     Noncoding,
     SlidingWindow,
     Scang,
-    Custom,
 }
 
 impl std::str::FromStr for MaskCategory {
@@ -89,7 +88,6 @@ impl std::str::FromStr for MaskCategory {
             "noncoding" => Ok(Self::Noncoding),
             "sliding-window" | "window" => Ok(Self::SlidingWindow),
             "scang" => Ok(Self::Scang),
-            "custom" => Ok(Self::Custom),
             _ => Err(format!("unknown mask: {s}")),
         }
     }

--- a/src/staar/scoring.rs
+++ b/src/staar/scoring.rs
@@ -72,7 +72,7 @@ struct MaskPlan {
 }
 
 impl MaskPlan {
-    fn build(categories: &[MaskCategory], out: &dyn Output) -> Self {
+    fn build(categories: &[MaskCategory]) -> Self {
         let mut gene_predicates: Vec<(MaskType, MaskPredicate)> = Vec::new();
         let mut want_windows = false;
         let mut want_scang = false;
@@ -85,7 +85,6 @@ impl MaskPlan {
                 }
                 MaskCategory::SlidingWindow => want_windows = true,
                 MaskCategory::Scang => want_scang = true,
-                MaskCategory::Custom => out.warn("Custom BED: not yet implemented"),
             }
         }
 
@@ -158,7 +157,7 @@ pub fn run_score_tests(
 ) -> Result<(ResultSet, Vec<crate::staar::output::IndividualRow>), CohortError> {
     out.status("Running score tests (carrier-indexed sparse)...");
 
-    let mut plan = MaskPlan::build(request.mask_categories, out);
+    let mut plan = MaskPlan::build(request.mask_categories);
     let mut individual_rows: Vec<crate::staar::output::IndividualRow> = Vec::new();
 
     // `score_one_window` always takes the cached-U/K path; SPA on windows
@@ -756,7 +755,7 @@ pub fn run_multi_score_tests(
     debug_assert_eq!(vcf_to_pheno.iter().filter(|p| p.is_some()).count(), null.n_samples);
     let n_pheno = null.n_samples;
 
-    let mut plan = MaskPlan::build(request.mask_categories, out);
+    let mut plan = MaskPlan::build(request.mask_categories);
 
     for ci in &manifest.chromosomes {
         let chrom: Chromosome = ci.name.parse().map_err(|e: String| CohortError::Input(e))?;


### PR DESCRIPTION
`MaskCategory::Custom` was declared but never instantiated. No CLI plumbing, no store metadata, no tests — the only code path that matched it just emitted a `"Custom BED: not yet implemented"` warning. Dropping the variant trims the dead match arm, shortens the CLI help line, and drops the unused `Output` handle from `MaskPlan::build`.

When a user-BED path actually ships it goes back under a named category, not under the same placeholder.

`cargo test --bin favor`: 299/299. `cargo clippy --bin favor --tests -- -D warnings`: clean.