### PR TITLE
staar: move burden effect off GeneResult

### DIFF
--- a/src/commands/ingest.rs
+++ b/src/commands/ingest.rs
@@ -592,12 +592,10 @@ fn apply_build_override(
         Some(GenomeBuild::Hg38) => {
             analysis.build_guess = BuildGuess::Hg38;
         }
-        None if analysis.format != InputFormat::Vcf => {
-            // Pre-setup ingest is a first-class path: skip build detection when
-            // no configured engine is available.
-            if engine.config_opt().is_some() {
-                let _ = ingest::detect::detect_build_and_coords(engine, analysis, first);
-            }
+        // Pre-setup ingest is a first-class path: skip build detection when
+        // no configured engine is available.
+        None if analysis.format != InputFormat::Vcf && engine.config_opt().is_some() => {
+            let _ = ingest::detect::detect_build_and_coords(engine, analysis, first);
         }
         None => {}
     }

--- a/src/commands/meta_staar.rs
+++ b/src/commands/meta_staar.rs
@@ -18,7 +18,8 @@ use crate::error::CohortError;
 use crate::output::Output;
 use crate::runtime::Engine;
 use crate::staar::masks::MaskGroup;
-use crate::staar::{self, GeneResult, MaskCategory, MaskType};
+use crate::staar::meta::MetaGeneResult;
+use crate::staar::{self, MaskCategory, MaskType};
 use crate::types::Chromosome;
 
 pub fn build_config(
@@ -171,7 +172,7 @@ fn run_all_chromosomes(
     known_loci: &[(String, u32, String, String)],
     engine: &DfEngine,
     out: &dyn Output,
-) -> Result<Vec<(MaskType, Vec<GeneResult>)>, CohortError> {
+) -> Result<Vec<(MaskType, Vec<MetaGeneResult>)>, CohortError> {
     let k = studies.len();
     let conditional = !known_loci.is_empty();
     let heterogeneous = matches!(
@@ -179,7 +180,7 @@ fn run_all_chromosomes(
         crate::cli::ConditionalModel::Heterogeneous
     );
     let chromosomes = discover_chromosomes(&studies[0].path);
-    let mut all_results: Vec<(MaskType, Vec<GeneResult>)> = Vec::new();
+    let mut all_results: Vec<(MaskType, Vec<MetaGeneResult>)> = Vec::new();
 
     for chrom in &chromosomes {
         out.status(&format!(
@@ -216,7 +217,7 @@ fn run_all_chromosomes(
         let segment_cache = load_segment_cache(studies, chrom, out);
 
         for (mask_type, groups) in &chrom_masks {
-            let results: Vec<GeneResult> = groups
+            let results: Vec<MetaGeneResult> = groups
                 .par_iter()
                 .filter_map(|group| {
                     if cond_indices.is_empty() {
@@ -366,7 +367,7 @@ fn discover_chromosomes(study_dir: &std::path::Path) -> Vec<String> {
 
 fn generate_summary(
     studies: &[staar::meta::StudyHandle],
-    results: &[(MaskType, Vec<GeneResult>)],
+    results: &[(MaskType, Vec<MetaGeneResult>)],
     config: &MetaStaarConfig,
     out: &dyn Output,
 ) {
@@ -376,8 +377,15 @@ fn generate_summary(
     let trait_names = vec![studies[0].meta.trait_name.clone()];
     let title = format!("MetaSTAAR Meta-Analysis ({k} studies, N={total_n})");
 
+    // `generate_report` is single-study-shaped; the burden effect columns
+    // only live in the parquet writer, not the summary HTML.
+    let report_results: Vec<(MaskType, Vec<staar::GeneResult>)> = results
+        .iter()
+        .map(|(mt, rs)| (*mt, rs.iter().map(|r| r.gene.clone()).collect()))
+        .collect();
+
     match staar::output::generate_report(
-        results,
+        &report_results,
         &trait_names,
         total_n,
         n_rare,
@@ -393,7 +401,7 @@ fn generate_summary(
 }
 
 fn write_meta_results(
-    all_mask_results: &[(MaskType, Vec<GeneResult>)],
+    all_mask_results: &[(MaskType, Vec<MetaGeneResult>)],
     output_dir: &std::path::Path,
     out: &dyn Output,
 ) -> Result<(), CohortError> {
@@ -414,7 +422,7 @@ fn write_meta_results(
 
 fn write_mask_results(
     mask_type: &MaskType,
-    results: &[GeneResult],
+    results: &[MetaGeneResult],
     channels: &[&str],
     output_dir: &std::path::Path,
     out: &dyn Output,
@@ -422,11 +430,12 @@ fn write_mask_results(
     let out_path = output_dir.join(format!("{}.parquet", mask_type.file_stem()));
     let n_channels = channels.len();
 
-    let mut sorted: Vec<&GeneResult> = results.iter().collect();
+    let mut sorted: Vec<&MetaGeneResult> = results.iter().collect();
     sorted.sort_by(|a, b| {
-        a.staar
+        a.gene
+            .staar
             .staar_o
-            .partial_cmp(&b.staar.staar_o)
+            .partial_cmp(&b.gene.staar.staar_o)
             .unwrap_or(std::cmp::Ordering::Equal)
     });
 
@@ -446,7 +455,7 @@ fn write_mask_results(
         .close()
         .map_err(|e| CohortError::Resource(format!("Parquet close: {e}")))?;
 
-    let n_sig = results.iter().filter(|r| r.staar.staar_o < 2.5e-6).count();
+    let n_sig = results.iter().filter(|r| r.gene.staar.staar_o < 2.5e-6).count();
     out.success(&format!(
         "  {} -> {} genes, {} significant",
         mask_type.file_stem(),
@@ -458,7 +467,7 @@ fn write_mask_results(
 }
 
 fn build_result_batch(
-    sorted: &[&GeneResult],
+    sorted: &[&MetaGeneResult],
     channels: &[&str],
     n_channels: usize,
 ) -> Result<(Arc<Schema>, RecordBatch), CohortError> {
@@ -479,14 +488,15 @@ fn build_result_batch(
         .collect();
 
     for r in sorted {
-        let s = &r.staar;
-        b_ensembl.append_value(&r.ensembl_id);
-        b_symbol.append_value(&r.gene_symbol);
-        b_chrom.append_value(r.chromosome.label());
-        b_start.append_value(r.start);
-        b_end.append_value(r.end);
-        b_nvariants.append_value(r.n_variants);
-        b_cmac.append_value(r.cumulative_mac);
+        let g = &r.gene;
+        let s = &g.staar;
+        b_ensembl.append_value(&g.ensembl_id);
+        b_symbol.append_value(&g.gene_symbol);
+        b_chrom.append_value(g.chromosome.label());
+        b_start.append_value(g.start);
+        b_end.append_value(g.end);
+        b_nvariants.append_value(g.n_variants);
+        b_cmac.append_value(g.cumulative_mac);
         b_burden_beta.append_value(r.burden_beta);
         b_burden_se.append_value(r.burden_se);
 

--- a/src/staar/meta.rs
+++ b/src/staar/meta.rs
@@ -23,6 +23,19 @@ use super::carrier::AnalysisVectors;
 use super::masks::MaskGroup;
 use super::score;
 use super::GeneResult;
+
+/// Meta-analysis per-gene result. Wraps a `GeneResult` with the
+/// unweighted burden effect size — only meaningful for meta runs, so it
+/// lives here instead of bloating `GeneResult` with NaN-80%-of-the-time
+/// fields on the single-study path.
+#[derive(Debug, Clone)]
+pub struct MetaGeneResult {
+    pub gene: GeneResult,
+    /// Unweighted burden coefficient β̂ = (1ᵀU)/(1ᵀK1).
+    pub burden_beta: f64,
+    /// SE of β̂: sqrt(1 / 1ᵀK1).
+    pub burden_se: f64,
+}
 use crate::column::{Col, STAAR_WEIGHTS};
 use crate::engine::DfEngine;
 use crate::error::CohortError;
@@ -546,7 +559,7 @@ pub fn meta_score_gene(
     meta_variants: &[MetaVariant],
     studies: &[StudyHandle],
     segment_cache: &HashMap<(usize, i32), SegmentCov>,
-) -> Option<GeneResult> {
+) -> Option<MetaGeneResult> {
     let indices: Vec<usize> = group
         .variant_indices
         .iter()
@@ -632,15 +645,17 @@ pub fn meta_score_gene(
     let (burden_beta, burden_se) = unweighted_burden_estimate(&u, &cov);
     let cmac: i64 = indices.iter().map(|&gi| meta_variants[gi].mac_total).sum();
 
-    Some(GeneResult {
-        ensembl_id: group.name.clone(),
-        gene_symbol: group.name.clone(),
-        chromosome: group.chromosome,
-        start: group.start,
-        end: group.end,
-        n_variants: m as u32,
-        cumulative_mac: cmac as u32,
-        staar: sr,
+    Some(MetaGeneResult {
+        gene: GeneResult {
+            ensembl_id: group.name.clone(),
+            gene_symbol: group.name.clone(),
+            chromosome: group.chromosome,
+            start: group.start,
+            end: group.end,
+            n_variants: m as u32,
+            cumulative_mac: cmac as u32,
+            staar: sr,
+        },
         burden_beta,
         burden_se,
     })
@@ -1190,7 +1205,7 @@ pub fn meta_score_gene_conditional(
     segment_cache: &HashMap<(usize, i32), SegmentCov>,
     known_loci_indices: &[usize],
     _heterogeneous: bool,
-) -> Option<GeneResult> {
+) -> Option<MetaGeneResult> {
     let gene_indices: Vec<usize> = group
         .variant_indices
         .iter()
@@ -1349,7 +1364,7 @@ fn finish_conditional(
     u_cond: &Mat<f64>,
     k_cond: &Mat<f64>,
     group: &MaskGroup,
-) -> Option<GeneResult> {
+) -> Option<MetaGeneResult> {
     let m_t = gene_indices.len();
 
     let mafs: Vec<f64> = gene_indices
@@ -1386,15 +1401,17 @@ fn finish_conditional(
         .map(|&gi| meta_variants[gi].mac_total)
         .sum();
 
-    Some(GeneResult {
-        ensembl_id: group.name.clone(),
-        gene_symbol: group.name.clone(),
-        chromosome: group.chromosome,
-        start: group.start,
-        end: group.end,
-        n_variants: m_t as u32,
-        cumulative_mac: cmac as u32,
-        staar: sr,
+    Some(MetaGeneResult {
+        gene: GeneResult {
+            ensembl_id: group.name.clone(),
+            gene_symbol: group.name.clone(),
+            chromosome: group.chromosome,
+            start: group.start,
+            end: group.end,
+            n_variants: m_t as u32,
+            cumulative_mac: cmac as u32,
+            staar: sr,
+        },
         burden_beta,
         burden_se,
     })
@@ -1529,12 +1546,12 @@ mod tests {
 
         let result = meta_score_gene(&group, &variants, &studies, &cache).expect("score");
         assert!(
-            (result.staar.staar_o - direct.staar_o).abs() < 1e-12,
+            (result.gene.staar.staar_o - direct.staar_o).abs() < 1e-12,
             "K=1 meta {} vs direct {}",
-            result.staar.staar_o,
+            result.gene.staar.staar_o,
             direct.staar_o
         );
-        assert_eq!(result.n_variants, m as u32);
+        assert_eq!(result.gene.n_variants, m as u32);
         assert!((result.burden_beta - expected_beta).abs() < 1e-12);
         assert!((result.burden_se - expected_se).abs() < 1e-12);
     }
@@ -1642,9 +1659,9 @@ mod tests {
 
         let result = meta_score_gene(&group, &variants, &studies, &cache).expect("score");
         assert!(
-            (result.staar.staar_o - direct.staar_o).abs() < 1e-12,
+            (result.gene.staar.staar_o - direct.staar_o).abs() < 1e-12,
             "K=2 split meta {} vs direct {}",
-            result.staar.staar_o,
+            result.gene.staar.staar_o,
             direct.staar_o
         );
     }

--- a/src/staar/mod.rs
+++ b/src/staar/mod.rs
@@ -154,9 +154,4 @@ pub struct GeneResult {
     pub n_variants: u32,
     pub cumulative_mac: u32,
     pub staar: score::StaarResult,
-    /// Unweighted burden coefficient β̂ = (1ᵀU)/(1ᵀK1) and its standard
-    /// error sqrt(1/(1ᵀK1)). Only the meta-analysis path populates these
-    /// today; single-study scoring leaves them NaN.
-    pub burden_beta: f64,
-    pub burden_se: f64,
 }

--- a/src/staar/output.rs
+++ b/src/staar/output.rs
@@ -1012,8 +1012,6 @@ mod tests {
                 acat_o: p,
                 staar_o: p,
             },
-            burden_beta: f64::NAN,
-            burden_se: f64::NAN,
         }
     }
 

--- a/src/staar/scoring.rs
+++ b/src/staar/scoring.rs
@@ -476,8 +476,6 @@ fn score_gene_masks(
                 n_variants: qualifying.len() as u32,
                 cumulative_mac: cmac,
                 staar,
-                burden_beta: f64::NAN,
-                burden_se: f64::NAN,
             },
         ));
     }
@@ -695,8 +693,6 @@ fn score_one_window(
         n_variants: m as u32,
         cumulative_mac: cmac,
         staar,
-        burden_beta: f64::NAN,
-        burden_se: f64::NAN,
     })
 }
 
@@ -899,8 +895,6 @@ fn score_chrom_genes_multi(
                         n_variants: qualifying.len() as u32,
                         cumulative_mac: cmac,
                         staar,
-                        burden_beta: f64::NAN,
-                        burden_se: f64::NAN,
                     },
                 ));
             }
@@ -1066,8 +1060,6 @@ fn score_one_window_multi(
         n_variants: m as u32,
         cumulative_mac: cmac,
         staar,
-        burden_beta: f64::NAN,
-        burden_se: f64::NAN,
     })
 }
 


### PR DESCRIPTION
`burden_beta` and `burden_se` only carried real values on the meta-analysis path; every single-study and window scorer initialized them to NaN. Two fields that were meaningful 20% of the time on a struct touched by every scoring site.

Moves both onto a new `MetaGeneResult { gene: GeneResult, burden_beta, burden_se }` owned by `src/staar/meta.rs`. The meta writer now consumes `&[&MetaGeneResult]`. `generate_report` stays single-study-shaped; the meta summary path clones the inner `GeneResult` since the HTML doesn't emit burden columns.

Net cut: six `burden_*: f64::NAN` initializers in scoring / output, plus two fields off the shared struct. No behaviour change — meta parquet schema is identical, invariance test is bit-identical.

`cargo test --bin favor`: 299/299. `cargo clippy --bin favor --tests -- -D warnings`: clean.