### PR TITLE
ingest: GDS / aGDS reader via vendored CoreArray FFI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - run: sudo apt-get update && sudo apt-get install -y liblzma-dev
       - uses: dtolnay/rust-toolchain@stable
       - uses: actions/cache@v4
         with:
@@ -33,6 +36,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - run: sudo apt-get update && sudo apt-get install -y liblzma-dev
       - uses: dtolnay/rust-toolchain@stable
       - uses: actions/cache@v4
         with:
@@ -49,6 +55,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - run: sudo apt-get update && sudo apt-get install -y liblzma-dev
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "crates/corearray-sys/vendor"]
+	path = crates/corearray-sys/vendor
+	url = https://github.com/CoreArray/GDSFormat.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,6 +721,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "corearray-sys"
+version = "0.1.0"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1732,6 +1739,7 @@ dependencies = [
  "arrow",
  "async-trait",
  "clap",
+ "corearray-sys",
  "datafusion",
  "dirs",
  "faer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
+[workspace]
+members = [".", "crates/corearray-sys"]
+resolver = "2"
+
 [package]
 name = "favor"
 version = "0.1.0"
@@ -28,6 +32,9 @@ statrs = "0.18"
 rayon = "1.10"
 walkdir = "2"
 memchr = "2"
+
+# GDS (SeqArray) ingest: FFI to vendored CoreArray C++ library
+corearray-sys = { path = "crates/corearray-sys" }
 
 # VCF → parquet: streaming parser + columnar writer
 noodles-vcf = "0.73"

--- a/crates/corearray-sys/Cargo.toml
+++ b/crates/corearray-sys/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "corearray-sys"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.75"
+description = "FFI bindings to the CoreArray GDS C++ library"
+license = "LGPL-3.0"
+links = "corearray"
+publish = false
+
+[dependencies]
+
+[build-dependencies]
+cc = "1"
+

--- a/crates/corearray-sys/build.rs
+++ b/crates/corearray-sys/build.rs
@@ -1,9 +1,11 @@
 // Compiles the vendored CoreArray GDS C++ library plus a thin C shim
 // (`cpp/shim.cpp`) that exposes a flat `extern "C"` surface to Rust.
 //
-// XZ (LZMA) is not built. SeqArray .gds files in normal use are LZ4- or
-// ZLIB-compressed; LZMA-compressed datasets will fail at read time with a
-// clear codec error rather than a link error.
+// LZMA support is compiled out via `COREARRAY_NO_LZMA`, which gates lines
+// 2164..2784 of dStream.cpp so no liblzma symbols are referenced. SeqArray
+// defaults to LZ4_RA / ZIP_RA for genotype storage, so this is the common
+// case. LZMA-compressed datasets will fail at read time with a CoreArray
+// codec error.
 
 use std::path::PathBuf;
 
@@ -63,6 +65,7 @@ fn main() {
         .include(&include)
         .include(&core)
         .include(&geno)
+        .define("COREARRAY_NO_LZMA", None)
         .flag_if_supported("-Wno-unused-parameter")
         .flag_if_supported("-Wno-unused-variable")
         .flag_if_supported("-Wno-unused-function")

--- a/crates/corearray-sys/build.rs
+++ b/crates/corearray-sys/build.rs
@@ -1,0 +1,101 @@
+// Compiles the vendored CoreArray GDS C++ library plus a thin C shim
+// (`cpp/shim.cpp`) that exposes a flat `extern "C"` surface to Rust.
+//
+// XZ (LZMA) is not built. SeqArray .gds files in normal use are LZ4- or
+// ZLIB-compressed; LZMA-compressed datasets will fail at read time with a
+// clear codec error rather than a link error.
+
+use std::path::PathBuf;
+
+fn main() {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let vendor = manifest.join("vendor");
+    let core = vendor.join("src/CoreArray");
+    let geno = vendor.join("src/GenoGDS");
+    let lz4 = vendor.join("src/LZ4");
+    let zlib = vendor.join("src/ZLIB");
+    let include = vendor.join("include");
+    let shim = manifest.join("cpp");
+
+    if !vendor.join("src/CoreArray/CoreArray.cpp").exists() {
+        panic!(
+            "vendor/ submodule not initialized. run: git submodule update --init --recursive"
+        );
+    }
+
+    let cpp_sources = [
+        "CoreArray.cpp",
+        "dAllocator.cpp",
+        "dAny.cpp",
+        "dBase.cpp",
+        "dBitGDS.cpp",
+        "dEndian.cpp",
+        "dFile.cpp",
+        "dParallel.cpp",
+        "dPlatform.cpp",
+        "dRealGDS.cpp",
+        "dSerial.cpp",
+        "dSparse.cpp",
+        "dStrGDS.cpp",
+        "dStream.cpp",
+        "dStruct.cpp",
+        "dVLIntGDS.cpp",
+    ];
+    let c_core = ["dParallel_Ext.c"];
+    let lz4_sources = ["lz4.c", "lz4hc.c", "lz4frame.c", "xxhash.c"];
+    let zlib_sources = [
+        "adler32.c",
+        "compress.c",
+        "crc32.c",
+        "deflate.c",
+        "infback.c",
+        "inffast.c",
+        "inflate.c",
+        "inftrees.c",
+        "trees.c",
+        "uncompr.c",
+        "zutil.c",
+    ];
+
+    let mut cxx = cc::Build::new();
+    cxx.cpp(true)
+        .std("c++11")
+        .include(&include)
+        .include(&core)
+        .include(&geno)
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-unused-variable")
+        .flag_if_supported("-Wno-unused-function")
+        .flag_if_supported("-Wno-deprecated-declarations")
+        .flag_if_supported("-Wno-misleading-indentation")
+        .flag_if_supported("-Wno-class-memaccess")
+        .flag_if_supported("-Wno-implicit-fallthrough");
+    for f in cpp_sources {
+        cxx.file(core.join(f));
+    }
+    cxx.file(geno.join("GenoGDS.cpp"));
+    cxx.file(shim.join("shim.cpp"));
+    cxx.compile("corearray_cpp");
+
+    let mut c_lib = cc::Build::new();
+    c_lib
+        .include(&include)
+        .include(&core)
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-implicit-function-declaration");
+    for f in c_core {
+        c_lib.file(core.join(f));
+    }
+    for f in lz4_sources {
+        c_lib.file(lz4.join(f));
+    }
+    for f in zlib_sources {
+        c_lib.file(zlib.join(f));
+    }
+    c_lib.compile("corearray_c");
+
+    println!("cargo:rerun-if-changed=cpp/shim.cpp");
+    println!("cargo:rerun-if-changed=cpp/shim.h");
+    println!("cargo:rerun-if-changed=vendor/src");
+    println!("cargo:rerun-if-changed=vendor/include");
+}

--- a/crates/corearray-sys/build.rs
+++ b/crates/corearray-sys/build.rs
@@ -1,11 +1,12 @@
 // Compiles the vendored CoreArray GDS C++ library plus a thin C shim
 // (`cpp/shim.cpp`) that exposes a flat `extern "C"` surface to Rust.
 //
-// LZMA support is compiled out via `COREARRAY_NO_LZMA`, which gates lines
-// 2164..2784 of dStream.cpp so no liblzma symbols are referenced. SeqArray
-// defaults to LZ4_RA / ZIP_RA for genotype storage, so this is the common
-// case. LZMA-compressed datasets will fail at read time with a CoreArray
-// codec error.
+// LZMA support uses the system liblzma instead of the bundled XZ tarball
+// (avoiding the upstream Makefile's tar/configure/make dance). The
+// `COREARRAY_USE_LZMA_EXT` define switches dStream.h's include from
+// `../XZ/api/lzma.h` to `<lzma.h>`. The link flag below pulls liblzma.so
+// in. Production aGDS files (e.g. CCDG WGS) use the LZMA_ra coder, so
+// LZMA cannot be dropped.
 
 use std::path::PathBuf;
 
@@ -65,7 +66,7 @@ fn main() {
         .include(&include)
         .include(&core)
         .include(&geno)
-        .define("COREARRAY_NO_LZMA", None)
+        .define("COREARRAY_USE_LZMA_EXT", None)
         .flag_if_supported("-Wno-unused-parameter")
         .flag_if_supported("-Wno-unused-variable")
         .flag_if_supported("-Wno-unused-function")
@@ -96,6 +97,8 @@ fn main() {
         c_lib.file(zlib.join(f));
     }
     c_lib.compile("corearray_c");
+
+    println!("cargo:rustc-link-lib=lzma");
 
     println!("cargo:rerun-if-changed=cpp/shim.cpp");
     println!("cargo:rerun-if-changed=cpp/shim.h");

--- a/crates/corearray-sys/cpp/shim.cpp
+++ b/crates/corearray-sys/cpp/shim.cpp
@@ -1,0 +1,135 @@
+#include "shim.h"
+#include "../vendor/src/CoreArray/CoreArray.h"
+
+#include <new>
+#include <string>
+#include <vector>
+
+using namespace CoreArray;
+
+struct CaFile {
+    CdGDSFile gds;
+    std::string err;
+};
+
+namespace {
+
+CdAllocArray *resolve_array(CaFile *f, const char *path) {
+    CdGDSObj *obj = f->gds.Root().Path(UTF8String(path));
+    if (!obj) {
+        f->err = std::string("path not found: ") + path;
+        return nullptr;
+    }
+    CdAllocArray *arr = dynamic_cast<CdAllocArray *>(obj);
+    if (!arr) {
+        f->err = std::string("not an allocatable array: ") + path;
+        return nullptr;
+    }
+    return arr;
+}
+
+template <typename Fn>
+int trap(CaFile *f, Fn &&body) {
+    try {
+        body();
+        return 0;
+    } catch (std::exception &e) {
+        f->err = e.what();
+    } catch (...) {
+        f->err = "unknown C++ exception";
+    }
+    return 1;
+}
+
+}  // namespace
+
+extern "C" {
+
+CaFile *corearray_open(const char *path) {
+    static bool registered = false;
+    if (!registered) {
+        RegisterClass();
+        registered = true;
+    }
+    CaFile *f = new (std::nothrow) CaFile;
+    if (!f) return nullptr;
+    try {
+        f->gds.LoadFile(path, true);
+        return f;
+    } catch (std::exception &e) {
+        f->err = e.what();
+        // Hand back the handle so callers can read the error message before close.
+        return f;
+    } catch (...) {
+        f->err = "unknown C++ exception during open";
+        return f;
+    }
+}
+
+void corearray_close(CaFile *f) {
+    if (!f) return;
+    try { f->gds.CloseFile(); } catch (...) {}
+    delete f;
+}
+
+const char *corearray_last_error(CaFile *f) {
+    return f ? f->err.c_str() : "null file handle";
+}
+
+int corearray_ndim(CaFile *f, const char *path, int32_t *out_ndim) {
+    return trap(f, [&]() {
+        CdAllocArray *arr = resolve_array(f, path);
+        if (!arr) throw ErrCoreArray("resolve_array failed");
+        *out_ndim = arr->DimCnt();
+    });
+}
+
+int corearray_dims(CaFile *f, const char *path, int32_t ndim, int64_t *out_dims) {
+    return trap(f, [&]() {
+        CdAllocArray *arr = resolve_array(f, path);
+        if (!arr) throw ErrCoreArray("resolve_array failed");
+        if (arr->DimCnt() != ndim) throw ErrCoreArray("ndim mismatch");
+        for (int i = 0; i < ndim; ++i) out_dims[i] = arr->GetDLen(i);
+    });
+}
+
+int corearray_read_int32(
+    CaFile *f, const char *path, int32_t ndim,
+    const int32_t *start, const int32_t *length, int32_t *out_buf) {
+    return trap(f, [&]() {
+        CdAllocArray *arr = resolve_array(f, path);
+        if (!arr) throw ErrCoreArray("resolve_array failed");
+        if (arr->DimCnt() != ndim) throw ErrCoreArray("ndim mismatch");
+        arr->ReadData(start, length, out_buf, svInt32);
+    });
+}
+
+int corearray_read_int8(
+    CaFile *f, const char *path, int32_t ndim,
+    const int32_t *start, const int32_t *length, int8_t *out_buf) {
+    return trap(f, [&]() {
+        CdAllocArray *arr = resolve_array(f, path);
+        if (!arr) throw ErrCoreArray("resolve_array failed");
+        if (arr->DimCnt() != ndim) throw ErrCoreArray("ndim mismatch");
+        arr->ReadData(start, length, out_buf, svInt8);
+    });
+}
+
+int corearray_read_string(
+    CaFile *f, const char *path, int32_t start, int32_t length,
+    corearray_str_cb cb, void *user) {
+    return trap(f, [&]() {
+        CdAllocArray *arr = resolve_array(f, path);
+        if (!arr) throw ErrCoreArray("resolve_array failed");
+        if (arr->DimCnt() != 1) throw ErrCoreArray("string array must be 1-d");
+        std::vector<UTF8String> tmp(length);
+        int32_t s = start, l = length;
+        arr->ReadData(&s, &l, tmp.data(), svStrUTF8);
+        for (int32_t i = 0; i < length; ++i) {
+            const UTF8String &s = tmp[i];
+            cb(user, i, s.data(), s.size());
+        }
+    });
+}
+
+}  // extern "C"

--- a/crates/corearray-sys/cpp/shim.cpp
+++ b/crates/corearray-sys/cpp/shim.cpp
@@ -1,6 +1,7 @@
 #include "shim.h"
 #include "../vendor/src/CoreArray/CoreArray.h"
 
+#include <mutex>
 #include <new>
 #include <string>
 #include <vector>
@@ -15,7 +16,10 @@ struct CaFile {
 namespace {
 
 CdAllocArray *resolve_array(CaFile *f, const char *path) {
-    CdGDSObj *obj = f->gds.Root().Path(UTF8String(path));
+    // PathEx returns null on not-found instead of throwing. Path() throws
+    // ErrGDSObj which our trap would translate, but the upstream message
+    // is less actionable than ours.
+    CdGDSObj *obj = f->gds.Root().PathEx(UTF8String(path));
     if (!obj) {
         f->err = std::string("path not found: ") + path;
         return nullptr;
@@ -46,11 +50,8 @@ int trap(CaFile *f, Fn &&body) {
 extern "C" {
 
 CaFile *corearray_open(const char *path) {
-    static bool registered = false;
-    if (!registered) {
-        RegisterClass();
-        registered = true;
-    }
+    static std::once_flag s_register_once;
+    std::call_once(s_register_once, []() { RegisterClass(); });
     CaFile *f = new (std::nothrow) CaFile;
     if (!f) return nullptr;
     try {

--- a/crates/corearray-sys/cpp/shim.h
+++ b/crates/corearray-sys/cpp/shim.h
@@ -1,0 +1,67 @@
+// Flat C surface over CoreArray's C++ API. Each entry point traps any C++
+// exception and converts it to a non-zero return code; the message is
+// retrievable via corearray_last_error.
+//
+// All functions return 0 on success.
+
+#ifndef COREARRAY_SHIM_H
+#define COREARRAY_SHIM_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct CaFile CaFile;
+
+CaFile *corearray_open(const char *path);
+void corearray_close(CaFile *file);
+
+const char *corearray_last_error(CaFile *file);
+
+// Returns the rank (number of dimensions) of the array at `path`.
+int corearray_ndim(CaFile *file, const char *path, int32_t *out_ndim);
+
+// Fills out_dims[0..ndim] with the per-axis sizes.
+int corearray_dims(CaFile *file, const char *path, int32_t ndim, int64_t *out_dims);
+
+// Reads a contiguous slab from an N-dim array, casting to int32. Caller passes
+// `start` and `length` arrays of `ndim` entries; total elements = product(length).
+int corearray_read_int32(
+    CaFile *file,
+    const char *path,
+    int32_t ndim,
+    const int32_t *start,
+    const int32_t *length,
+    int32_t *out_buf);
+
+// Same shape as read_int32 but casts to int8. Used for bit2-packed dosages
+// in /genotype/data, where per-allele codes 0/1/2/3 (3=missing) come out as
+// signed 8-bit integers; pair adjacent alleles for diploid dosage.
+int corearray_read_int8(
+    CaFile *file,
+    const char *path,
+    int32_t ndim,
+    const int32_t *start,
+    const int32_t *length,
+    int8_t *out_buf);
+
+// Reads a 1-d UTF-8 string array slice. For each string in [start, start+length),
+// invokes `cb(user, idx, ptr, len)`. Strings are NOT null-terminated; copy if you
+// need to keep them past the callback.
+typedef void (*corearray_str_cb)(void *user, int32_t idx, const char *ptr, size_t len);
+int corearray_read_string(
+    CaFile *file,
+    const char *path,
+    int32_t start,
+    int32_t length,
+    corearray_str_cb cb,
+    void *user);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/crates/corearray-sys/src/lib.rs
+++ b/crates/corearray-sys/src/lib.rs
@@ -1,0 +1,65 @@
+//! Raw `extern "C"` bindings to the CoreArray GDS library via the C++ shim
+//! in `cpp/shim.cpp`. All functions return 0 on success; non-zero return
+//! means the file's last_error string is populated.
+//!
+//! Higher-level Rust code (`favor::ingest::gds`) builds the streaming
+//! `VariantReader` on top of this surface.
+
+#![allow(non_camel_case_types)]
+
+use std::ffi::c_void;
+use std::os::raw::{c_char, c_int};
+
+#[repr(C)]
+pub struct CaFile {
+    _private: [u8; 0],
+}
+
+pub type corearray_str_cb = extern "C" fn(
+    user: *mut c_void,
+    idx: i32,
+    ptr: *const c_char,
+    len: usize,
+);
+
+extern "C" {
+    pub fn corearray_open(path: *const c_char) -> *mut CaFile;
+    pub fn corearray_close(file: *mut CaFile);
+
+    pub fn corearray_last_error(file: *mut CaFile) -> *const c_char;
+
+    pub fn corearray_ndim(file: *mut CaFile, path: *const c_char, out_ndim: *mut i32) -> c_int;
+    pub fn corearray_dims(
+        file: *mut CaFile,
+        path: *const c_char,
+        ndim: i32,
+        out_dims: *mut i64,
+    ) -> c_int;
+
+    pub fn corearray_read_int32(
+        file: *mut CaFile,
+        path: *const c_char,
+        ndim: i32,
+        start: *const i32,
+        length: *const i32,
+        out_buf: *mut i32,
+    ) -> c_int;
+
+    pub fn corearray_read_int8(
+        file: *mut CaFile,
+        path: *const c_char,
+        ndim: i32,
+        start: *const i32,
+        length: *const i32,
+        out_buf: *mut i8,
+    ) -> c_int;
+
+    pub fn corearray_read_string(
+        file: *mut CaFile,
+        path: *const c_char,
+        start: i32,
+        length: i32,
+        cb: corearray_str_cb,
+        user: *mut c_void,
+    ) -> c_int;
+}

--- a/crates/corearray-sys/tests/smoke.rs
+++ b/crates/corearray-sys/tests/smoke.rs
@@ -54,6 +54,181 @@ fn open_nonexistent_path_surfaces_error() {
     }
 }
 
+/// Ignored by default. Set `FAVOR_AGDS_PROBE_PATH` to a real production
+/// SeqArray (a)GDS file (e.g. one of the 136k CCDG chr*.agds files) and
+/// run with `--ignored` to probe the FFI against real data.
+///
+/// Verifies open + reads `/sample.id` count, `/position` count, and the
+/// first three positions. No annotation channels are touched.
+#[test]
+#[ignore]
+fn probe_real_agds_from_env() {
+    let path = match std::env::var("FAVOR_AGDS_PROBE_PATH") {
+        Ok(p) => p,
+        Err(_) => panic!("set FAVOR_AGDS_PROBE_PATH to a real .agds file"),
+    };
+    let cpath = CString::new(path.as_str()).unwrap();
+    let sample_id = CString::new("/sample.id").unwrap();
+    let position = CString::new("/position").unwrap();
+    let chromosome = CString::new("/chromosome").unwrap();
+    let allele = CString::new("/allele").unwrap();
+    let geno = CString::new("/genotype/data").unwrap();
+
+    unsafe {
+        let f = corearray_sys::corearray_open(cpath.as_ptr());
+        assert!(!f.is_null());
+        let err = read_err(f);
+        assert!(err.is_empty(), "open '{path}' reported: {err}");
+
+        // /sample.id is a 1-d string array.
+        let mut nd = 0i32;
+        assert_eq!(
+            corearray_sys::corearray_ndim(f, sample_id.as_ptr(), &mut nd),
+            0,
+            "/sample.id ndim: {}",
+            read_err(f)
+        );
+        assert_eq!(nd, 1, "/sample.id should be 1-d");
+        let mut sample_dims = [0i64];
+        assert_eq!(
+            corearray_sys::corearray_dims(f, sample_id.as_ptr(), 1, sample_dims.as_mut_ptr()),
+            0,
+            "/sample.id dims: {}",
+            read_err(f)
+        );
+        let n_samples = sample_dims[0];
+        eprintln!("/sample.id: {n_samples} samples");
+        assert!(n_samples > 0, "expected at least one sample");
+
+        // /chromosome and /position are 1-d, length == n_variants.
+        let mut pos_dims = [0i64];
+        assert_eq!(
+            corearray_sys::corearray_dims(f, position.as_ptr(), 1, pos_dims.as_mut_ptr()),
+            0,
+            "/position dims: {}",
+            read_err(f)
+        );
+        let n_variants = pos_dims[0];
+        eprintln!("/position: {n_variants} variants");
+        assert!(n_variants > 0);
+
+        // /genotype/data is 3-d: (ploidy, sample, variant).
+        assert_eq!(
+            corearray_sys::corearray_ndim(f, geno.as_ptr(), &mut nd),
+            0,
+            "/genotype/data ndim: {}",
+            read_err(f)
+        );
+        eprintln!("/genotype/data ndim: {nd}");
+        assert!(nd == 2 || nd == 3, "expected 2- or 3-d genotype array");
+
+        let mut gd = vec![0i64; nd as usize];
+        assert_eq!(
+            corearray_sys::corearray_dims(f, geno.as_ptr(), nd, gd.as_mut_ptr()),
+            0,
+            "/genotype/data dims: {}",
+            read_err(f)
+        );
+        eprintln!("/genotype/data dims: {gd:?}");
+
+        // Read first three /position entries.
+        let count = 3.min(n_variants as i32);
+        let mut pos = vec![0i32; count as usize];
+        let s = [0i32];
+        let l = [count];
+        assert_eq!(
+            corearray_sys::corearray_read_int32(
+                f,
+                position.as_ptr(),
+                1,
+                s.as_ptr(),
+                l.as_ptr(),
+                pos.as_mut_ptr(),
+            ),
+            0,
+            "read_int32 /position: {}",
+            read_err(f)
+        );
+        eprintln!("first {count} positions: {pos:?}");
+
+        // SeqArray /genotype/data is 3-d (variant, sample, ploidy) with
+        // dims = [n_variants, n_samples, 2]. Read one variant: pin axis 0
+        // to 0, take all samples and ploidies. 2-d fallback (sample, variant).
+        let (geno_count, gs, gl): (usize, Vec<i32>, Vec<i32>) = if nd == 3 {
+            let nsamp = gd[1] as i64;
+            let ploidy = gd[2] as i64;
+            ((nsamp * ploidy) as usize, vec![0, 0, 0], vec![1, nsamp as i32, ploidy as i32])
+        } else {
+            let nsamp = gd[0] as i64;
+            (nsamp as usize, vec![0, 0], vec![nsamp as i32, 1])
+        };
+        let mut buf = vec![0i8; geno_count];
+        assert_eq!(
+            corearray_sys::corearray_read_int8(
+                f,
+                geno.as_ptr(),
+                nd,
+                gs.as_ptr(),
+                gl.as_ptr(),
+                buf.as_mut_ptr(),
+            ),
+            0,
+            "read_int8 /genotype/data: {}",
+            read_err(f)
+        );
+        let nonneg = buf.iter().filter(|&&c| c >= 0).count();
+        let neg = buf.iter().filter(|&&c| c < 0).count();
+        eprintln!("variant 0 dosage: {nonneg} non-missing alleles, {neg} missing");
+
+        // /chromosome and /allele are 1-d string arrays. Read first one.
+        let dummy_cb: corearray_sys::corearray_str_cb = {
+            extern "C" fn cb(
+                _u: *mut std::ffi::c_void,
+                idx: i32,
+                ptr: *const std::os::raw::c_char,
+                len: usize,
+            ) {
+                let s = unsafe {
+                    std::str::from_utf8(std::slice::from_raw_parts(ptr as *const u8, len))
+                        .unwrap_or("?")
+                };
+                eprintln!("  string[{idx}] = {s:?}");
+            }
+            cb
+        };
+        eprintln!("first /chromosome:");
+        assert_eq!(
+            corearray_sys::corearray_read_string(
+                f,
+                chromosome.as_ptr(),
+                0,
+                1,
+                dummy_cb,
+                std::ptr::null_mut(),
+            ),
+            0,
+            "read /chromosome: {}",
+            read_err(f)
+        );
+        eprintln!("first /allele:");
+        assert_eq!(
+            corearray_sys::corearray_read_string(
+                f,
+                allele.as_ptr(),
+                0,
+                1,
+                dummy_cb,
+                std::ptr::null_mut(),
+            ),
+            0,
+            "read /allele: {}",
+            read_err(f)
+        );
+
+        corearray_sys::corearray_close(f);
+    }
+}
+
 #[test]
 fn ndim_on_missing_node_returns_error() {
     let path = fixture("CEU_Exon.gds");

--- a/crates/corearray-sys/tests/smoke.rs
+++ b/crates/corearray-sys/tests/smoke.rs
@@ -1,0 +1,78 @@
+//! End-to-end exercise of the FFI roundtrip against a real upstream-bundled
+//! GDS file. The fixture is `vendor/examples/data/CEU_Exon.gds`, which ships
+//! with `CoreArray/GDSFormat` and is in CoreArray binary format. Confirms
+//! that the C++ shim builds, links, and that open/close/last_error/ndim/dims
+//! produce sane values on real bytes — independent of whether higher-level
+//! layouts (SNPGDS vs SeqArray) match.
+
+use std::ffi::{CStr, CString};
+use std::path::PathBuf;
+
+fn fixture(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("vendor/examples/data")
+        .join(name)
+}
+
+fn read_err(file: *mut corearray_sys::CaFile) -> String {
+    unsafe {
+        let p = corearray_sys::corearray_last_error(file);
+        if p.is_null() {
+            String::new()
+        } else {
+            CStr::from_ptr(p).to_string_lossy().into_owned()
+        }
+    }
+}
+
+#[test]
+fn open_and_close_real_gds_file() {
+    let path = fixture("CEU_Exon.gds");
+    assert!(path.exists(), "fixture missing: {}", path.display());
+    let cpath = CString::new(path.to_str().unwrap()).unwrap();
+
+    unsafe {
+        let f = corearray_sys::corearray_open(cpath.as_ptr());
+        assert!(!f.is_null(), "corearray_open returned null");
+
+        let err = read_err(f);
+        assert!(err.is_empty(), "open reported error: {err}");
+
+        corearray_sys::corearray_close(f);
+    }
+}
+
+#[test]
+fn open_nonexistent_path_surfaces_error() {
+    let cpath = CString::new("/no/such/file.gds").unwrap();
+    unsafe {
+        let f = corearray_sys::corearray_open(cpath.as_ptr());
+        assert!(!f.is_null(), "shim should hand back a handle even on open failure");
+        let err = read_err(f);
+        assert!(!err.is_empty(), "expected error message, got empty");
+        corearray_sys::corearray_close(f);
+    }
+}
+
+#[test]
+fn ndim_on_missing_node_returns_error() {
+    let path = fixture("CEU_Exon.gds");
+    let cpath = CString::new(path.to_str().unwrap()).unwrap();
+    let bogus = CString::new("/this/node/does/not/exist").unwrap();
+    unsafe {
+        let f = corearray_sys::corearray_open(cpath.as_ptr());
+        assert!(!f.is_null());
+        assert!(read_err(f).is_empty(), "open clean");
+
+        let mut ndim = 0i32;
+        let rc = corearray_sys::corearray_ndim(f, bogus.as_ptr(), &mut ndim);
+        assert_ne!(rc, 0, "ndim on missing path should return non-zero");
+        let err = read_err(f);
+        assert!(
+            err.contains("path not found") || err.contains("does not exist") || !err.is_empty(),
+            "expected non-empty error, got '{err}'"
+        );
+
+        corearray_sys::corearray_close(f);
+    }
+}

--- a/src/commands/ingest.rs
+++ b/src/commands/ingest.rs
@@ -129,6 +129,15 @@ pub fn run_ingest(
         }
         return ingest_vcf(engine, config, n_samples, out);
     }
+    if analysis.format == InputFormat::Gds {
+        return Err(CohortError::Input(
+            "GDS reader is registered and usable programmatically \
+             (FormatRegistry::detect + FormatHandler::open_reader), but the \
+             cohort-build CLI dispatch has not yet been generalized off the \
+             VCF-specific ingest_vcfs path. Convert the .gds to VCF for now."
+                .into(),
+        ));
+    }
     if config.emit_sql || analysis.needs_intervention() {
         return emit_sql_script(config, &analysis, out);
     }
@@ -571,7 +580,7 @@ fn register_tabular_inputs(
                 ))?;
             }
         }
-        InputFormat::Vcf => unreachable!(),
+        InputFormat::Vcf | InputFormat::Gds => unreachable!(),
     }
     Ok(())
 }
@@ -594,7 +603,9 @@ fn apply_build_override(
         }
         // Pre-setup ingest is a first-class path: skip build detection when
         // no configured engine is available.
-        None if analysis.format != InputFormat::Vcf && engine.config_opt().is_some() => {
+        None if !matches!(analysis.format, InputFormat::Vcf | InputFormat::Gds)
+            && engine.config_opt().is_some() =>
+        {
             let _ = ingest::detect::detect_build_and_coords(engine, analysis, first);
         }
         None => {}

--- a/src/ingest/format.rs
+++ b/src/ingest/format.rs
@@ -216,7 +216,12 @@ impl FormatHandler for GdsHandler {
     }
 
     fn detect(&self, path: &Path, header: &[u8]) -> DetectResult {
-        if path_lower(path).ends_with(".gds") {
+        // .agds is the STAARpipeline convention for annotated GDS. We treat
+        // it as plain GDS — read genotypes only, skip /annotation/info/...
+        // channels. Annotations come from `favor annotate` against fresh
+        // FAVOR parquet, so we sidestep any staleness in the embedded copy.
+        let name = path_lower(path);
+        if name.ends_with(".gds") || name.ends_with(".agds") {
             return DetectResult::Yes(0.95);
         }
         // CoreArray GDS magic: first 8 bytes are "COREARRA" (followed by Yx00).

--- a/src/ingest/format.rs
+++ b/src/ingest/format.rs
@@ -208,6 +208,50 @@ impl FormatHandler for TsvHandler {
     }
 }
 
+pub struct GdsHandler;
+
+impl FormatHandler for GdsHandler {
+    fn name(&self) -> &'static str {
+        "GDS"
+    }
+
+    fn detect(&self, path: &Path, header: &[u8]) -> DetectResult {
+        if path_lower(path).ends_with(".gds") {
+            return DetectResult::Yes(0.95);
+        }
+        // CoreArray GDS magic: first 8 bytes are "COREARRA" (followed by Yx00).
+        if header.starts_with(b"COREARRA") {
+            return DetectResult::Yes(1.0);
+        }
+        DetectResult::No
+    }
+
+    fn schema(&self, _path: &Path) -> Result<Schema, CohortError> {
+        Ok(Schema::new(vec![
+            Field::new("chromosome", DataType::Utf8, false),
+            Field::new("position", DataType::Int32, false),
+            Field::new("ref", DataType::Utf8, false),
+            Field::new("alt", DataType::Utf8, false),
+        ]))
+    }
+
+    fn input_format(&self) -> InputFormat {
+        InputFormat::Gds
+    }
+
+    fn delimiter(&self, _path: &Path) -> Option<Delimiter> {
+        None
+    }
+
+    fn open_reader(
+        &self,
+        path: &Path,
+        _threads: usize,
+    ) -> Result<Box<dyn VariantReader>, CohortError> {
+        Ok(Box::new(super::gds::GdsVariantReader::open(path)?))
+    }
+}
+
 pub struct CsvHandler;
 
 impl FormatHandler for CsvHandler {
@@ -257,6 +301,7 @@ impl FormatRegistry {
         Self {
             handlers: vec![
                 Box::new(VcfHandler),
+                Box::new(GdsHandler),
                 Box::new(ParquetHandler),
                 Box::new(TsvHandler),
                 Box::new(CsvHandler),

--- a/src/ingest/gds.rs
+++ b/src/ingest/gds.rs
@@ -1,0 +1,357 @@
+//! GDS (SeqArray / CoreArray) variant reader.
+//!
+//! Reads /sample.id, /chromosome, /position, /allele once at open time. Then
+//! streams one variant at a time, decoding the bit2-packed /genotype/data
+//! slice into a per-variant samples_text buffer that mirrors the VCF reader's
+//! contract (FORMAT-prefixed, tab-separated, "GT" column only).
+//!
+//! /genotype/data is a 3-d int8 array with axes (ploidy, sample, variant).
+//! Per-allele codes are 0=ref, 1..k=alt_k, anything < 0 is missing
+//! (CoreArray emits the bit-pattern's signed extension; we treat any negative
+//! value as missing). Diploid GT is built as "a/b" using these codes; "." for
+//! missing alleles.
+
+#![allow(dead_code)] // GdsVariantReader is wired via FormatHandler trait object
+
+use std::ffi::{c_void, CStr, CString};
+use std::fmt::Write as _;
+use std::os::raw::c_char;
+use std::path::Path;
+
+use crate::error::CohortError;
+
+use super::reader::{RawRecord, VariantReader};
+
+/// Compile-time CStr from a byte literal with explicit NUL terminator.
+const fn c(bytes: &'static [u8]) -> &'static CStr {
+    // SAFETY: caller passes a literal that ends with `\0` and contains no
+    // interior NULs.
+    unsafe { CStr::from_bytes_with_nul_unchecked(bytes) }
+}
+
+const PATH_SAMPLE_ID: &CStr = c(b"/sample.id\0");
+const PATH_POSITION: &CStr = c(b"/position\0");
+const PATH_CHROMOSOME: &CStr = c(b"/chromosome\0");
+const PATH_ALLELE: &CStr = c(b"/allele\0");
+const PATH_GENOTYPE_DATA: &CStr = c(b"/genotype/data\0");
+
+pub struct GdsVariantReader {
+    file: GdsHandle,
+    sample_count: i32,
+    variant_count: i32,
+    ploidy: i32,
+    chromosome: Vec<String>,
+    position: Vec<i32>,
+    allele: Vec<String>,
+    geno_buf: Vec<i8>,
+    samples_text: String,
+}
+
+impl GdsVariantReader {
+    pub fn open(path: &Path) -> Result<Self, CohortError> {
+        let file = GdsHandle::open(path)?;
+
+        let sample_count = file.array_dim(PATH_SAMPLE_ID, 0)? as i32;
+        let variant_count = file.array_dim(PATH_POSITION, 0)? as i32;
+
+        let geno_dims = file.array_dims(PATH_GENOTYPE_DATA, 3)?;
+        let ploidy = geno_dims[0] as i32;
+        if geno_dims[1] as i32 != sample_count || geno_dims[2] as i32 != variant_count {
+            return Err(CohortError::Input(format!(
+                "GDS '{}': /genotype/data dims {:?} disagree with sample_count={} variant_count={}",
+                path.display(),
+                geno_dims,
+                sample_count,
+                variant_count
+            )));
+        }
+
+        let chromosome = file.read_string_array_1d(PATH_CHROMOSOME, 0, variant_count)?;
+        let position = file.read_int32_array_1d(PATH_POSITION, 0, variant_count)?;
+        let allele = file.read_string_array_1d(PATH_ALLELE, 0, variant_count)?;
+
+        let geno_buf = vec![0i8; (ploidy as usize) * (sample_count as usize)];
+        let samples_text =
+            String::with_capacity(2 + (sample_count as usize) * (ploidy as usize * 2 + 1));
+
+        Ok(Self {
+            file,
+            sample_count,
+            variant_count,
+            ploidy,
+            chromosome,
+            position,
+            allele,
+            geno_buf,
+            samples_text,
+        })
+    }
+
+    pub fn sample_count(&self) -> i32 {
+        self.sample_count
+    }
+
+    pub fn sample_names(&self) -> Result<Vec<String>, CohortError> {
+        self.file
+            .read_string_array_1d(PATH_SAMPLE_ID, 0, self.sample_count)
+    }
+}
+
+impl VariantReader for GdsVariantReader {
+    fn for_each(
+        &mut self,
+        f: &mut dyn for<'a> FnMut(RawRecord<'a>) -> Result<(), CohortError>,
+    ) -> Result<(), CohortError> {
+        for v in 0..self.variant_count {
+            let start = [0i32, 0, v];
+            let length = [self.ploidy, self.sample_count, 1];
+            self.file
+                .read_int8_slice(PATH_GENOTYPE_DATA, &start, &length, &mut self.geno_buf)?;
+
+            self.samples_text.clear();
+            self.samples_text.push_str("GT");
+            for s in 0..(self.sample_count as usize) {
+                self.samples_text.push('\t');
+                for p in 0..(self.ploidy as usize) {
+                    if p > 0 {
+                        self.samples_text.push('/');
+                    }
+                    let code = self.geno_buf[p * (self.sample_count as usize) + s];
+                    if code < 0 {
+                        self.samples_text.push('.');
+                    } else {
+                        let _ = write!(self.samples_text, "{}", code);
+                    }
+                }
+            }
+
+            let alleles = self.allele[v as usize].as_str();
+            let (ref_allele, alt_alleles) = match alleles.find(',') {
+                Some(i) => (&alleles[..i], &alleles[i + 1..]),
+                None => (alleles, ""),
+            };
+
+            let rec = RawRecord {
+                chromosome: self.chromosome[v as usize].as_str(),
+                position: self.position[v as usize],
+                ref_allele,
+                alt_alleles,
+                rsid: None,
+                qual: None,
+                filter: None,
+                samples_text: self.samples_text.as_str(),
+            };
+            f(rec)?;
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Thin RAII wrapper over the corearray-sys FFI. All entry points return
+// Result<_, CohortError> with the upstream error string preserved.
+
+struct GdsHandle {
+    inner: *mut corearray_sys::CaFile,
+    path: String,
+}
+
+unsafe impl Send for GdsHandle {}
+
+impl GdsHandle {
+    fn open(path: &Path) -> Result<Self, CohortError> {
+        let cpath = CString::new(path.as_os_str().to_string_lossy().as_bytes())
+            .map_err(|e| CohortError::Input(format!("path contains NUL: {e}")))?;
+        let inner = unsafe { corearray_sys::corearray_open(cpath.as_ptr()) };
+        if inner.is_null() {
+            return Err(CohortError::Input(format!(
+                "GDS open: allocation failed for '{}'",
+                path.display()
+            )));
+        }
+        let h = GdsHandle {
+            inner,
+            path: path.display().to_string(),
+        };
+        // CoreArray surfaces open failures via last_error rather than a null handle.
+        let err = h.last_error();
+        if !err.is_empty() {
+            return Err(CohortError::Input(format!(
+                "GDS open '{}': {err}",
+                path.display()
+            )));
+        }
+        Ok(h)
+    }
+
+    fn last_error(&self) -> String {
+        unsafe {
+            let p = corearray_sys::corearray_last_error(self.inner);
+            if p.is_null() {
+                String::new()
+            } else {
+                std::ffi::CStr::from_ptr(p).to_string_lossy().into_owned()
+            }
+        }
+    }
+
+    fn err<T>(&self, where_: &str) -> Result<T, CohortError> {
+        Err(CohortError::Input(format!(
+            "GDS {where_} on '{}': {}",
+            self.path,
+            self.last_error()
+        )))
+    }
+
+    fn array_dim(&self, path: &std::ffi::CStr, axis: usize) -> Result<i64, CohortError> {
+        let mut ndim: i32 = 0;
+        let rc = unsafe { corearray_sys::corearray_ndim(self.inner, path.as_ptr(), &mut ndim) };
+        if rc != 0 {
+            return self.err("ndim");
+        }
+        if axis as i32 >= ndim {
+            return Err(CohortError::Input(format!(
+                "GDS '{}': axis {axis} out of range for ndim={ndim} on {}",
+                self.path,
+                path.to_string_lossy()
+            )));
+        }
+        let mut dims = vec![0i64; ndim as usize];
+        let rc = unsafe {
+            corearray_sys::corearray_dims(self.inner, path.as_ptr(), ndim, dims.as_mut_ptr())
+        };
+        if rc != 0 {
+            return self.err("dims");
+        }
+        Ok(dims[axis])
+    }
+
+    fn array_dims(
+        &self,
+        path: &std::ffi::CStr,
+        expected_ndim: i32,
+    ) -> Result<Vec<i64>, CohortError> {
+        let mut ndim: i32 = 0;
+        let rc = unsafe { corearray_sys::corearray_ndim(self.inner, path.as_ptr(), &mut ndim) };
+        if rc != 0 {
+            return self.err("ndim");
+        }
+        if ndim != expected_ndim {
+            return Err(CohortError::Input(format!(
+                "GDS '{}': '{}' has ndim={ndim}, expected {expected_ndim}",
+                self.path,
+                path.to_string_lossy()
+            )));
+        }
+        let mut dims = vec![0i64; ndim as usize];
+        let rc = unsafe {
+            corearray_sys::corearray_dims(self.inner, path.as_ptr(), ndim, dims.as_mut_ptr())
+        };
+        if rc != 0 {
+            return self.err("dims");
+        }
+        Ok(dims)
+    }
+
+    fn read_int32_array_1d(
+        &self,
+        path: &std::ffi::CStr,
+        start: i32,
+        length: i32,
+    ) -> Result<Vec<i32>, CohortError> {
+        let mut buf = vec![0i32; length as usize];
+        let s = [start];
+        let l = [length];
+        let rc = unsafe {
+            corearray_sys::corearray_read_int32(
+                self.inner,
+                path.as_ptr(),
+                1,
+                s.as_ptr(),
+                l.as_ptr(),
+                buf.as_mut_ptr(),
+            )
+        };
+        if rc != 0 {
+            return self.err("read_int32");
+        }
+        Ok(buf)
+    }
+
+    fn read_int8_slice(
+        &self,
+        path: &std::ffi::CStr,
+        start: &[i32],
+        length: &[i32],
+        out: &mut [i8],
+    ) -> Result<(), CohortError> {
+        let need: usize = length.iter().map(|&n| n as usize).product();
+        if out.len() < need {
+            return Err(CohortError::Input(format!(
+                "GDS read_int8: buffer of {} too small for {need} elements",
+                out.len()
+            )));
+        }
+        let rc = unsafe {
+            corearray_sys::corearray_read_int8(
+                self.inner,
+                path.as_ptr(),
+                start.len() as i32,
+                start.as_ptr(),
+                length.as_ptr(),
+                out.as_mut_ptr(),
+            )
+        };
+        if rc != 0 {
+            return self.err("read_int8");
+        }
+        Ok(())
+    }
+
+    fn read_string_array_1d(
+        &self,
+        path: &std::ffi::CStr,
+        start: i32,
+        length: i32,
+    ) -> Result<Vec<String>, CohortError> {
+        let mut out: Vec<String> = vec![String::new(); length as usize];
+        let user_ptr: *mut Vec<String> = &mut out;
+
+        extern "C" fn cb(
+            user: *mut c_void,
+            idx: i32,
+            ptr: *const c_char,
+            len: usize,
+        ) {
+            unsafe {
+                let v = &mut *(user as *mut Vec<String>);
+                let bytes = std::slice::from_raw_parts(ptr as *const u8, len);
+                v[idx as usize] = String::from_utf8_lossy(bytes).into_owned();
+            }
+        }
+
+        let rc = unsafe {
+            corearray_sys::corearray_read_string(
+                self.inner,
+                path.as_ptr(),
+                start,
+                length,
+                cb,
+                user_ptr as *mut c_void,
+            )
+        };
+        if rc != 0 {
+            return self.err("read_string");
+        }
+        Ok(out)
+    }
+}
+
+impl Drop for GdsHandle {
+    fn drop(&mut self) {
+        if !self.inner.is_null() {
+            unsafe { corearray_sys::corearray_close(self.inner) };
+            self.inner = std::ptr::null_mut();
+        }
+    }
+}

--- a/src/ingest/gds.rs
+++ b/src/ingest/gds.rs
@@ -5,11 +5,17 @@
 //! slice into a per-variant samples_text buffer that mirrors the VCF reader's
 //! contract (FORMAT-prefixed, tab-separated, "GT" column only).
 //!
-//! /genotype/data is a 3-d int8 array with axes (ploidy, sample, variant).
-//! Per-allele codes are 0=ref, 1..k=alt_k, anything < 0 is missing
-//! (CoreArray emits the bit-pattern's signed extension; we treat any negative
-//! value as missing). Diploid GT is built as "a/b" using these codes; "." for
-//! missing alleles.
+//! /genotype/data is a 3-d int8 array with axes (variant, sample, ploidy)
+//! — verified against the production CCDG 136k aGDS where `dims =
+//! [n_variants, n_samples, 2]`. Per-allele codes are 0=ref, 1..k=alt_k,
+//! anything < 0 is missing (CoreArray emits the bit-pattern's signed
+//! extension; we treat any negative value as missing). Diploid GT is built
+//! as "a/b" using these codes; "." for missing alleles.
+//!
+//! Embedded /annotation/info channels are intentionally skipped. Annotations
+//! come from `favor annotate` against fresh FAVOR parquet, so .agds files
+//! are treated as plain GDS for ingest. This sidesteps any staleness in the
+//! annotations baked into a given .agds at the time it was built.
 
 #![allow(dead_code)] // GdsVariantReader is wired via FormatHandler trait object
 
@@ -54,9 +60,10 @@ impl GdsVariantReader {
         let sample_count = file.array_dim(PATH_SAMPLE_ID, 0)? as i32;
         let variant_count = file.array_dim(PATH_POSITION, 0)? as i32;
 
+        // SeqArray stores /genotype/data as (variant, sample, ploidy).
+        // Verified on CCDG 136k aGDS: dims = [n_variants, n_samples, 2].
         let geno_dims = file.array_dims(PATH_GENOTYPE_DATA, 3)?;
-        let ploidy = geno_dims[0] as i32;
-        if geno_dims[1] as i32 != sample_count || geno_dims[2] as i32 != variant_count {
+        if geno_dims[0] as i32 != variant_count || geno_dims[1] as i32 != sample_count {
             return Err(CohortError::Input(format!(
                 "GDS '{}': /genotype/data dims {:?} disagree with sample_count={} variant_count={}",
                 path.display(),
@@ -65,12 +72,13 @@ impl GdsVariantReader {
                 variant_count
             )));
         }
+        let ploidy = geno_dims[2] as i32;
 
         let chromosome = file.read_string_array_1d(PATH_CHROMOSOME, 0, variant_count)?;
         let position = file.read_int32_array_1d(PATH_POSITION, 0, variant_count)?;
         let allele = file.read_string_array_1d(PATH_ALLELE, 0, variant_count)?;
 
-        let geno_buf = vec![0i8; (ploidy as usize) * (sample_count as usize)];
+        let geno_buf = vec![0i8; (sample_count as usize) * (ploidy as usize)];
         let samples_text =
             String::with_capacity(2 + (sample_count as usize) * (ploidy as usize * 2 + 1));
 
@@ -102,9 +110,13 @@ impl VariantReader for GdsVariantReader {
         &mut self,
         f: &mut dyn for<'a> FnMut(RawRecord<'a>) -> Result<(), CohortError>,
     ) -> Result<(), CohortError> {
+        let ploidy_us = self.ploidy as usize;
         for v in 0..self.variant_count {
-            let start = [0i32, 0, v];
-            let length = [self.ploidy, self.sample_count, 1];
+            // (variant, sample, ploidy) layout: pin axis 0 to v, take all
+            // samples and ploidies. Output buffer is laid out (sample, ploidy)
+            // row-major: index [s * ploidy + p].
+            let start = [v, 0i32, 0];
+            let length = [1, self.sample_count, self.ploidy];
             self.file
                 .read_int8_slice(PATH_GENOTYPE_DATA, &start, &length, &mut self.geno_buf)?;
 
@@ -112,11 +124,11 @@ impl VariantReader for GdsVariantReader {
             self.samples_text.push_str("GT");
             for s in 0..(self.sample_count as usize) {
                 self.samples_text.push('\t');
-                for p in 0..(self.ploidy as usize) {
+                for p in 0..ploidy_us {
                     if p > 0 {
                         self.samples_text.push('/');
                     }
-                    let code = self.geno_buf[p * (self.sample_count as usize) + s];
+                    let code = self.geno_buf[s * ploidy_us + p];
                     if code < 0 {
                         self.samples_text.push('.');
                     } else {

--- a/src/ingest/mod.rs
+++ b/src/ingest/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod detect;
 pub mod format;
+pub mod gds;
 pub mod reader;
 pub mod sql;
 pub mod vcf;
@@ -21,6 +22,7 @@ pub enum InputFormat {
     Vcf,
     Tabular,
     Parquet,
+    Gds,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -143,6 +145,10 @@ pub fn detect_format(path: &Path) -> Result<(InputFormat, Option<Delimiter>), Co
 
     if name.ends_with(".parquet") {
         return Ok((InputFormat::Parquet, None));
+    }
+
+    if name.ends_with(".gds") {
+        return Ok((InputFormat::Gds, None));
     }
 
     if name.ends_with(".tsv")
@@ -313,6 +319,36 @@ pub fn analyze(path: &Path) -> Result<Analysis, CohortError> {
                 rsid_col: None,
             })
         }
+
+        InputFormat::Gds => Ok(Analysis {
+            format,
+            delimiter: None,
+            raw_columns: vec![
+                "chromosome".into(),
+                "position".into(),
+                "allele".into(),
+            ],
+            columns: vec![
+                ColumnMapping {
+                    input_name: "chromosome".into(),
+                    canonical: "chromosome",
+                },
+                ColumnMapping {
+                    input_name: "position".into(),
+                    canonical: "position",
+                },
+            ],
+            ambiguous: vec![],
+            unmapped: vec![],
+            join_key: JoinKey::ChromPosRefAlt,
+            build_guess: BuildGuess::Unknown,
+            coord_base: CoordBase::OneBased,
+            chr_col: Some("chromosome".into()),
+            pos_col: Some("position".into()),
+            ref_col: None,
+            alt_col: None,
+            rsid_col: None,
+        }),
 
         InputFormat::Tabular => {
             let delim = delimiter.unwrap_or(Delimiter::Tab);

--- a/src/ingest/mod.rs
+++ b/src/ingest/mod.rs
@@ -147,7 +147,9 @@ pub fn detect_format(path: &Path) -> Result<(InputFormat, Option<Delimiter>), Co
         return Ok((InputFormat::Parquet, None));
     }
 
-    if name.ends_with(".gds") {
+    // .agds (STAARpipeline annotated GDS) is treated as plain GDS:
+    // genotypes are read, embedded /annotation/info channels are skipped.
+    if name.ends_with(".gds") || name.ends_with(".agds") {
         return Ok((InputFormat::Gds, None));
     }
 

--- a/src/ingest/sql.rs
+++ b/src/ingest/sql.rs
@@ -18,7 +18,7 @@ pub fn generate_select(analysis: &Analysis) -> String {
     match analysis.format {
         InputFormat::Tabular => write_tabular_select(&mut sql, analysis),
         InputFormat::Parquet => write_parquet_select(&mut sql, analysis),
-        InputFormat::Vcf => write_vcf_stub(&mut sql),
+        InputFormat::Vcf | InputFormat::Gds => write_vcf_stub(&mut sql),
     }
 
     sql
@@ -48,14 +48,14 @@ pub fn generate_script(analysis: &Analysis, input_path: &Path, output_path: &Pat
                 "-- (programmatic: engine.register_parquet(\"_ingest_input\", path))"
             );
         }
-        InputFormat::Vcf => {}
+        InputFormat::Vcf | InputFormat::Gds => {}
     }
     let _ = writeln!(script);
     let _ = writeln!(script, "-- Transformation query:");
     let _ = writeln!(script, "{select}");
     let _ = writeln!(script);
 
-    if analysis.format != InputFormat::Vcf {
+    if !matches!(analysis.format, InputFormat::Vcf | InputFormat::Gds) {
         let _ = writeln!(script, "-- Execute as:");
         let _ = writeln!(script, "-- COPY (<above query>)");
         let _ = writeln!(script, "--   TO '{}/'", output_path.display());


### PR DESCRIPTION
GDS / aGDS read via a vendored CoreArray FFI. aGDS is treated as plain GDS, embedded /annotation/info channels are skipped. Annotations come from `favor annotate` against fresh FAVOR parquet so we don't carry whatever was baked in when someone built the .agds.

Layout:
- `crates/corearray-sys` is a sys-crate. Vendors CoreArray/GDSFormat as a submodule, builds it with cc::Build, links the system liblzma. C++ shim in `cpp/shim.cpp`, raw bindings in `src/lib.rs`.
- `src/ingest/gds.rs` is the `VariantReader` impl. Reads /sample.id, /chromosome, /position, /allele on open, streams /genotype/data per variant.
- `GdsHandler` registered in the format registry. Detects `.gds`, `.agds`, or the COREARRA magic.

Reader and registry work programmatically. The cohort-build CLI returns "convert to VCF for now" because `ingest_vcfs` is still noodles-only. Generalizing that off noodles is the follow-up.

Probed against the 136k CCDG aGDS at `/n/holystore01/LABS/xlin/Lab/zhouhufeng/Data/CAD/CCDG_F3/aGDSv2/ccdg_genome_136k_chrY.agds` (13G, LZMA_ra). Opens, 136959 samples, 14292827 chrY variants, /genotype/data dims `[variants, samples, 2]`, variant 0 has 273918 non-missing alleles. /chromosome[0]="Y", /allele[0]="C,T". Probe lives at `crates/corearray-sys/tests/smoke.rs::probe_real_agds_from_env`, ignored, takes path from `FAVOR_AGDS_PROBE_PATH`.

`cargo test --workspace` passes locally: 342 favor, 3 smoke, 1 ignored.

CI:
- `submodules: recursive` on checkout, otherwise vendor/ is empty and build.rs panics.
- `apt-get install liblzma-dev`, ubuntu-latest only ships the liblzma5 runtime.