### PR TITLE
ingest: route .gds/.agds through the cohort-build path

### DIFF
--- a/crates/corearray-sys/tests/smoke.rs
+++ b/crates/corearray-sys/tests/smoke.rs
@@ -155,11 +155,11 @@ fn probe_real_agds_from_env() {
         // dims = [n_variants, n_samples, 2]. Read one variant: pin axis 0
         // to 0, take all samples and ploidies. 2-d fallback (sample, variant).
         let (geno_count, gs, gl): (usize, Vec<i32>, Vec<i32>) = if nd == 3 {
-            let nsamp = gd[1] as i64;
-            let ploidy = gd[2] as i64;
+            let nsamp = gd[1];
+            let ploidy = gd[2];
             ((nsamp * ploidy) as usize, vec![0, 0, 0], vec![1, nsamp as i32, ploidy as i32])
         } else {
-            let nsamp = gd[0] as i64;
+            let nsamp = gd[0];
             (nsamp as usize, vec![0, 0], vec![nsamp as i32, 1])
         };
         let mut buf = vec![0i8; geno_count];

--- a/src/commands/ingest.rs
+++ b/src/commands/ingest.rs
@@ -10,7 +10,6 @@ use crate::ingest::format::FormatRegistry;
 use crate::ingest::{self, BuildGuess, InputFormat};
 use crate::output::{bail_if_cancelled, Output};
 use crate::runtime::Engine;
-use crate::staar::genotype::read_sample_names;
 use crate::store::cohort::{BuildOpts, CohortId, CohortSources, ProbeReason, StoreProbe};
 use crate::store::list::{VariantSet, VariantSetKind, VariantSetWriter};
 
@@ -122,21 +121,16 @@ pub fn run_ingest(
         return run_ingest_dry(config, &analysis, out);
     }
 
-    if analysis.format == InputFormat::Vcf {
-        let n_samples = read_sample_names(first)?.len();
+    if matches!(analysis.format, InputFormat::Vcf | InputFormat::Gds) {
+        let handler = ingest::format::handler_for_format(analysis.format)?;
+        let n_samples = handler
+            .open_reader(first, engine.resources().threads)?
+            .sample_names()?
+            .len();
         if config.annotations.is_some() && n_samples > 0 {
-            return run_cohort_build(engine, config, n_samples, out);
+            return run_cohort_build(engine, config, analysis.format, n_samples, out);
         }
-        return ingest_vcf(engine, config, n_samples, out);
-    }
-    if analysis.format == InputFormat::Gds {
-        return Err(CohortError::Input(
-            "GDS reader is registered and usable programmatically \
-             (FormatRegistry::detect + FormatHandler::open_reader), but the \
-             cohort-build CLI dispatch has not yet been generalized off the \
-             VCF-specific ingest_vcfs path. Convert the .gds to VCF for now."
-                .into(),
-        ));
+        return ingest_vcf(engine, config, analysis.format, n_samples, out);
     }
     if config.emit_sql || analysis.needs_intervention() {
         return emit_sql_script(config, &analysis, out);
@@ -147,6 +141,7 @@ pub fn run_ingest(
 fn run_cohort_build(
     engine: &Engine,
     config: &IngestConfig,
+    genotype_format: InputFormat,
     n_samples: usize,
     out: &dyn Output,
 ) -> Result<(), CohortError> {
@@ -223,6 +218,7 @@ fn run_cohort_build(
     let result = cohort.build_or_load(
         CohortSources {
             genotypes: &config.inputs,
+            genotype_format,
             annotations: annotations_path,
         },
         BuildOpts {
@@ -307,10 +303,12 @@ fn validate_all_same_format(
 fn ingest_vcf(
     engine: &Engine,
     config: &IngestConfig,
+    genotype_format: InputFormat,
     n_samples: usize,
     out: &dyn Output,
 ) -> Result<(), CohortError> {
     let first = &config.inputs[0];
+    let handler = ingest::format::handler_for_format(genotype_format)?;
 
     if config.emit_sql {
         let analysis = ingest::analyze(first)?;
@@ -319,7 +317,7 @@ fn ingest_vcf(
         std::fs::write(&script_path, &script).map_err(|e| {
             CohortError::Resource(format!("Cannot write '{}': {e}", script_path.display()))
         })?;
-        out.status(&format!("VCF hint script: {}", script_path.display()));
+        out.status(&format!("SQL hint script: {}", script_path.display()));
         return Ok(());
     }
 
@@ -328,16 +326,18 @@ fn ingest_vcf(
 
     if dual_write {
         out.status(&format!(
-            "Ingesting {} VCF file(s) + extracting genotypes ({} samples, {}, {} threads)",
+            "Ingesting {} {} file(s) + extracting genotypes ({} samples, {}, {} threads)",
             config.inputs.len(),
+            handler.name(),
             n_samples,
             resources.memory_human(),
             resources.threads
         ));
     } else {
         out.status(&format!(
-            "Ingesting {} VCF file(s) ({}, {} threads)",
+            "Ingesting {} {} file(s) ({}, {} threads)",
             config.inputs.len(),
+            handler.name(),
             resources.memory_human(),
             resources.threads
         ));
@@ -351,6 +351,7 @@ fn ingest_vcf(
         // Parallel path: each file gets its own worker.
         let result = ingest::vcf::ingest_vcfs_parallel(
             &config.inputs,
+            handler.as_ref(),
             &config.output,
             if dual_write { Some(geno_dir.as_path()) } else { None },
             n_samples,
@@ -368,13 +369,15 @@ fn ingest_vcf(
         let vs = vs_writer.finish()?;
 
         if dual_write {
-            let sample_names = read_sample_names(first)?;
-            let source_vcfs: Vec<String> = config.inputs.iter().map(|p| p.display().to_string()).collect();
+            let sample_names = handler
+                .open_reader(first, resources.threads)?
+                .sample_names()?;
+            let source_paths: Vec<String> = config.inputs.iter().map(|p| p.display().to_string()).collect();
             let meta = crate::staar::genotype::GenotypeMeta {
                 version: 1,
                 n_samples,
                 chromosomes: vs.chromosomes().iter().map(|c| c.to_string()).collect(),
-                source_vcfs,
+                source_vcfs: source_paths,
             };
             let meta_path = geno_dir.join("genotypes.json");
             std::fs::write(&meta_path, serde_json::to_string_pretty(&meta)
@@ -407,6 +410,7 @@ fn ingest_vcf(
 
         let result = ingest::vcf::ingest_vcfs(
             &config.inputs,
+            handler.as_ref(),
             &mut vs_writer,
             geno_writer.as_mut(),
             resources.memory_bytes,
@@ -417,9 +421,11 @@ fn ingest_vcf(
         let vs = vs_writer.finish()?;
 
         if let Some(gw) = geno_writer {
-            let sample_names = read_sample_names(first)?;
-            let source_vcfs = config.inputs.iter().map(|p| p.display().to_string()).collect();
-            let geno_result = gw.finish(&sample_names, source_vcfs)?;
+            let sample_names = handler
+                .open_reader(first, resources.threads)?
+                .sample_names()?;
+            let source_paths = config.inputs.iter().map(|p| p.display().to_string()).collect();
+            let geno_result = gw.finish(&sample_names, source_paths)?;
             out.success(&format!(
                 "  Genotypes: {} variants x {} samples -> {}",
                 result.genotype_variants, n_samples, geno_result.output_dir.display()

--- a/src/ingest/format.rs
+++ b/src/ingest/format.rs
@@ -353,3 +353,20 @@ impl FormatRegistry {
         self.handlers.push(handler);
     }
 }
+
+/// Build a fresh handler instance for a given format. Used by the
+/// ingest dispatch path where the format has already been detected and
+/// the caller wants a `Box<dyn FormatHandler>` it can hand into the
+/// streaming path. Tabular formats return an error because they don't
+/// expose `open_reader`.
+pub fn handler_for_format(
+    format: InputFormat,
+) -> Result<Box<dyn FormatHandler + Send + Sync>, CohortError> {
+    match format {
+        InputFormat::Vcf => Ok(Box::new(VcfHandler)),
+        InputFormat::Gds => Ok(Box::new(GdsHandler)),
+        InputFormat::Parquet | InputFormat::Tabular => Err(CohortError::Input(format!(
+            "format {format:?} does not support variant streaming"
+        ))),
+    }
+}

--- a/src/ingest/gds.rs
+++ b/src/ingest/gds.rs
@@ -98,14 +98,14 @@ impl GdsVariantReader {
     pub fn sample_count(&self) -> i32 {
         self.sample_count
     }
-
-    pub fn sample_names(&self) -> Result<Vec<String>, CohortError> {
-        self.file
-            .read_string_array_1d(PATH_SAMPLE_ID, 0, self.sample_count)
-    }
 }
 
 impl VariantReader for GdsVariantReader {
+    fn sample_names(&mut self) -> Result<Vec<String>, CohortError> {
+        self.file
+            .read_string_array_1d(PATH_SAMPLE_ID, 0, self.sample_count)
+    }
+
     fn for_each(
         &mut self,
         f: &mut dyn for<'a> FnMut(RawRecord<'a>) -> Result<(), CohortError>,

--- a/src/ingest/reader.rs
+++ b/src/ingest/reader.rs
@@ -36,6 +36,11 @@ pub trait VariantReader: Send {
         &mut self,
         f: &mut dyn for<'a> FnMut(RawRecord<'a>) -> Result<(), CohortError>,
     ) -> Result<(), CohortError>;
+
+    /// Sample names in the order they appear in the per-record `samples_text`.
+    /// Reading is allowed to do work (header parse, FFI call), so callers
+    /// should cache the result if they need it more than once.
+    fn sample_names(&mut self) -> Result<Vec<String>, CohortError>;
 }
 
 #[cfg(test)]

--- a/src/ingest/vcf.rs
+++ b/src/ingest/vcf.rs
@@ -287,6 +287,14 @@ impl VcfVariantReader {
 }
 
 impl VariantReader for VcfVariantReader {
+    fn sample_names(&mut self) -> Result<Vec<String>, CohortError> {
+        // Re-reads the header from disk. Acceptable because the trait's
+        // sample_names() is called at most a handful of times per file
+        // (cohort-build sample lookup, sidecar write, header-consistency check)
+        // and the current open Reader has already advanced past the header.
+        crate::staar::genotype::read_sample_names(&self.path)
+    }
+
     fn for_each(
         &mut self,
         f: &mut dyn for<'a> FnMut(RawRecord<'a>) -> Result<(), CohortError>,
@@ -699,6 +707,7 @@ impl<'a> RecordContext<'a> {
     fn ingest_files(
         &mut self,
         files: &[impl AsRef<Path>],
+        handler: &dyn super::format::FormatHandler,
         threads: usize,
         output: &dyn Output,
     ) -> Result<(), CohortError> {
@@ -712,12 +721,12 @@ impl<'a> RecordContext<'a> {
                     input_path.file_name().unwrap_or_default().to_string_lossy()
                 ));
             }
-            let mut reader = VcfVariantReader::open(input_path, threads)?;
+            let mut reader = handler.open_reader(input_path, threads)?;
             let label = format!(
                 "ingesting {}",
                 input_path.file_name().unwrap_or_default().to_string_lossy()
             );
-            self.drive(&mut reader, &label, output)?;
+            self.drive(reader.as_mut(), &label, output)?;
             self.finish_file();
         }
         Ok(())
@@ -728,7 +737,8 @@ impl<'a> RecordContext<'a> {
 /// is written — this is the standalone extraction path used by the cohort
 /// store when variants have already been ingested separately.
 pub fn stream_genotypes(
-    vcf_paths: &[PathBuf],
+    paths: &[PathBuf],
+    handler: &(dyn super::format::FormatHandler + Send + Sync),
     gw: &mut GenotypeWriter,
     memory_budget: u64,
     threads: usize,
@@ -736,13 +746,15 @@ pub fn stream_genotypes(
     output: &dyn Output,
 ) -> Result<(), CohortError> {
     let mut ctx = RecordContext::new_genotype_only(gw, memory_budget, geno_dir, None);
-    ctx.ingest_files(vcf_paths, threads, output)
+    ctx.ingest_files(paths, handler, threads, output)
 }
 
-/// Stream one or more VCF files to per-chromosome parquet files (sequential).
+/// Stream one or more variant files to per-chromosome parquet (sequential).
+/// Format-agnostic: caller picks the handler (VCF, GDS, ...).
 #[allow(clippy::too_many_arguments)]
 pub fn ingest_vcfs(
     input_paths: &[PathBuf],
+    handler: &(dyn super::format::FormatHandler + Send + Sync),
     vs_writer: &mut VariantSetWriter,
     geno_writer: Option<&mut GenotypeWriter>,
     memory_budget: u64,
@@ -761,14 +773,16 @@ pub fn ingest_vcfs(
         memory_budget as f64 / (1024.0 * 1024.0 * 1024.0)
     ));
 
-    ctx.ingest_files(input_paths, threads, output)?;
+    ctx.ingest_files(input_paths, handler, threads, output)?;
     ctx.flush_into_vs(vs_writer)
 }
 
-/// Validate all VCF files have identical sample lists. Reads headers in
-/// parallel via rayon. Returns the shared sample names on success.
-fn validate_headers_parallel(
+/// Validate that all input files report identical sample lists. Routes
+/// through the format handler so this works for VCF (header parse) and
+/// GDS (FFI read of /sample.id) alike.
+fn validate_sample_consistency(
     paths: &[PathBuf],
+    handler: &(dyn super::format::FormatHandler + Send + Sync),
     n_samples: usize,
 ) -> Result<(), CohortError> {
     use rayon::prelude::*;
@@ -777,9 +791,9 @@ fn validate_headers_parallel(
         return Ok(());
     }
 
-    let first_samples = crate::staar::genotype::read_sample_names(&paths[0])?;
+    let first_samples = handler.open_reader(&paths[0], 1)?.sample_names()?;
     paths[1..].par_iter().try_for_each(|p| {
-        let samples = crate::staar::genotype::read_sample_names(p)?;
+        let samples = handler.open_reader(p, 1)?.sample_names()?;
         if samples.len() != first_samples.len() {
             return Err(CohortError::Input(format!(
                 "Sample count mismatch: '{}' has {} samples but '{}' has {}",
@@ -790,7 +804,7 @@ fn validate_headers_parallel(
         if samples != first_samples {
             return Err(CohortError::Input(format!(
                 "Sample order mismatch between '{}' and '{}'. \
-                 All VCF files must have identical samples in the same order.",
+                 All input files must have identical samples in the same order.",
                 paths[0].display(), p.display(),
             )));
         }
@@ -798,12 +812,15 @@ fn validate_headers_parallel(
     })
 }
 
-/// Parallel multi-file VCF ingest. Files are chunked across N workers,
-/// each worker processes its chunk sequentially with a single RecordContext.
-/// N is bounded by thread count. Validates headers before spawning.
+/// Parallel multi-file ingest. Files are chunked across N workers, each
+/// worker processes its chunk sequentially with a single RecordContext.
+/// N is bounded by thread count. Validates sample consistency before
+/// spawning. The handler is passed to each worker so this works for any
+/// VariantReader-backed format (VCF, GDS, ...).
 #[allow(clippy::too_many_arguments)]
 pub fn ingest_vcfs_parallel(
     input_paths: &[PathBuf],
+    handler: &(dyn super::format::FormatHandler + Send + Sync),
     output_dir: &Path,
     geno_dir: Option<&Path>,
     n_samples: usize,
@@ -821,7 +838,7 @@ pub fn ingest_vcfs_parallel(
 
     if n_samples > 0 {
         output.status("  Validating sample consistency across files...");
-        validate_headers_parallel(input_paths, n_samples)?;
+        validate_sample_consistency(input_paths, handler, n_samples)?;
     }
 
     let n_workers = input_paths.len().min(threads);
@@ -851,7 +868,7 @@ pub fn ingest_vcfs_parallel(
         .enumerate()
         .map(|(worker_id, file_chunk)| {
             run_worker(
-                worker_id, &file_chunk, output_dir, geno_dir,
+                worker_id, &file_chunk, handler, output_dir, geno_dir,
                 n_samples, memory_per_worker,
                 chromosome_filter.cloned(),
                 output,
@@ -886,6 +903,7 @@ pub fn ingest_vcfs_parallel(
 fn run_worker(
     worker_id: usize,
     file_chunk: &[&PathBuf],
+    handler: &(dyn super::format::FormatHandler + Send + Sync),
     output_dir: &Path,
     geno_dir: Option<&Path>,
     n_samples: usize,
@@ -904,7 +922,7 @@ fn run_worker(
         output_dir.to_path_buf(), Some(worker_id),
         chromosome_filter,
     );
-    ctx.ingest_files(file_chunk, 1, output)?;
+    ctx.ingest_files(file_chunk, handler, 1, output)?;
     let result = ctx.flush()?;
     if let Some(mut g) = gw {
         g.flush_all()?;

--- a/src/staar/genotype.rs
+++ b/src/staar/genotype.rs
@@ -39,33 +39,36 @@ pub struct GenotypeResult {
 }
 
 pub fn extract_genotypes(
-    vcf_paths: &[PathBuf],
+    genotype_paths: &[PathBuf],
+    handler: &(dyn crate::ingest::format::FormatHandler + Send + Sync),
     output_dir: &Path,
     available_memory: u64,
     threads: usize,
     output: &dyn Output,
 ) -> Result<GenotypeResult, CohortError> {
-    if vcf_paths.is_empty() {
-        return Err(CohortError::Input("No VCF files provided.".into()));
+    if genotype_paths.is_empty() {
+        return Err(CohortError::Input("No genotype files provided.".into()));
     }
 
-    let sample_names = read_sample_names(&vcf_paths[0])?;
+    let sample_names = handler
+        .open_reader(&genotype_paths[0], threads)?
+        .sample_names()?;
     let n_samples = sample_names.len();
     if n_samples == 0 {
         return Err(CohortError::Input(
-            "VCF has no samples. STAAR requires a multi-sample VCF.".into(),
+            "Input has no samples. STAAR requires a multi-sample input.".into(),
         ));
     }
 
-    for vcf_path in &vcf_paths[1..] {
-        let file_samples = read_sample_names(vcf_path)?;
+    for path in &genotype_paths[1..] {
+        let file_samples = handler.open_reader(path, threads)?.sample_names()?;
         if file_samples != sample_names {
             return Err(CohortError::Input(format!(
                 "Sample mismatch: '{}' has {} samples but '{}' has {}. \
-                 All VCF files must have identical samples in the same order.",
-                vcf_paths[0].display(),
+                 All input files must have identical samples in the same order.",
+                genotype_paths[0].display(),
                 sample_names.len(),
-                vcf_path.display(),
+                path.display(),
                 file_samples.len()
             )));
         }
@@ -74,7 +77,7 @@ pub fn extract_genotypes(
     output.status(&format!(
         "Extracting genotypes: {} samples, {} file(s), {} threads, {:.1}G memory",
         n_samples,
-        vcf_paths.len(),
+        genotype_paths.len(),
         threads,
         available_memory as f64 / (1024.0 * 1024.0 * 1024.0)
     ));
@@ -83,7 +86,8 @@ pub fn extract_genotypes(
     let mut gw = GenotypeWriter::new(n_samples, &geno_dir, available_memory)?;
 
     crate::ingest::vcf::stream_genotypes(
-        vcf_paths,
+        genotype_paths,
+        handler,
         &mut gw,
         available_memory,
         threads,
@@ -92,12 +96,15 @@ pub fn extract_genotypes(
     )?;
 
     let total_variants = gw.variant_count();
-    let source_vcfs = vcf_paths.iter().map(|p| p.display().to_string()).collect();
-    let result = gw.finish(&sample_names, source_vcfs)?;
+    let source_paths = genotype_paths
+        .iter()
+        .map(|p| p.display().to_string())
+        .collect();
+    let result = gw.finish(&sample_names, source_paths)?;
 
     output.success(&format!(
         "Extracted {total_variants} variants × {n_samples} samples from {} file(s)",
-        vcf_paths.len(),
+        genotype_paths.len(),
     ));
 
     Ok(result)

--- a/src/staar/pipeline.rs
+++ b/src/staar/pipeline.rs
@@ -578,9 +578,11 @@ impl<'a> StaarPipeline<'a> {
         };
 
         let geno_staging_dir = self.config.output_dir.join(".geno_staging");
+        let (genotype_format, _) = crate::ingest::detect_format(&genotypes[0])?;
         self.cohort().build_or_load(
             crate::store::cohort::CohortSources {
                 genotypes: &genotypes,
+                genotype_format,
                 annotations: &annotations,
             },
             crate::store::cohort::BuildOpts {

--- a/src/store/cohort/handle.rs
+++ b/src/store/cohort/handle.rs
@@ -11,6 +11,7 @@ use std::sync::OnceLock;
 
 use crate::column;
 use crate::error::CohortError;
+use crate::ingest::format::handler_for_format;
 use crate::output::Output;
 use crate::runtime::Engine;
 use crate::store::Store;
@@ -26,6 +27,10 @@ use super::{
 
 pub struct CohortSources<'a> {
     pub genotypes: &'a [PathBuf],
+    /// Genotype-side input format. Caller has already detected this via
+    /// `FormatRegistry::detect`. The cohort builder uses it to pick the
+    /// right `FormatHandler` for sample-name reads and per-variant streaming.
+    pub genotype_format: crate::ingest::InputFormat,
     pub annotations: &'a Path,
 }
 
@@ -154,7 +159,11 @@ impl<'a> CohortHandle<'a> {
             })?;
         }
 
-        let CohortSources { genotypes, annotations } = sources;
+        let CohortSources {
+            genotypes,
+            genotype_format,
+            annotations,
+        } = sources;
         let BuildOpts { staging_dir, rebuild, probe: probe_result } = opts;
         let res = engine.resources();
 
@@ -188,8 +197,10 @@ impl<'a> CohortHandle<'a> {
             "  Extracting genotypes from {} VCF file(s)...",
             genotypes.len()
         ));
+        let handler = handler_for_format(genotype_format)?;
         let geno = crate::staar::genotype::extract_genotypes(
             genotypes,
+            handler.as_ref(),
             staging_dir,
             res.memory_bytes,
             res.threads,


### PR DESCRIPTION
Follow-up to #137. The reader landed there but the CLI still bounced .gds/.agds inputs because the cohort-build path was noodles-coupled. This routes them through the same handler the VCF path uses.

`VariantReader` gets `sample_names`. `extract_genotypes` and `ingest_vcfs` take `&dyn FormatHandler`. `CohortSources` carries the detected format. That's it.

cargo test/clippy clean. Probe still passes on the 13G chrY aGDS.

Refs #69. Doesn't close it — the close gate is an actual end-to-end `favor ingest cohort.agds` on a real production cohort, which hasn't been run yet.